### PR TITLE
Move name field so it appears first in JSON output.

### DIFF
--- a/src/error/utils.ts
+++ b/src/error/utils.ts
@@ -149,7 +149,7 @@ export function createTaggedError<TErrorName extends `${string}Error`>(
 ): TaggedErrorFactories<TErrorName> {
 	const errorConstructor = (
 		error: TaggedErrorWithoutName<TErrorName>,
-	): TaggedError<TErrorName> => ({ ...error, name }) as TaggedError<TErrorName>;
+	): TaggedError<TErrorName> => ({ name, ...error }) as TaggedError<TErrorName>;
 
 	const errName = name.replace(
 		/Error$/,


### PR DESCRIPTION
- Fixes https://github.com/wellcrafted-dev/wellcrafted/issues/53.
- Confirmed problem and fix with local script:

```ts
import { tryAsync } from "./src/result/index";
import { createTaggedError } from "./src/error/index";

// Define your error with factory function
const { ApiError, ApiErr } = createTaggedError("ApiError");
type ApiError = ReturnType<typeof ApiError>;

// Wrap any throwing operation
const { data, error } = await tryAsync({
  try: () => fetch('/api/user').then(r => r.json()),
  mapErr: (error) => ApiErr({
    message: "Failed to fetch user",
    context: { endpoint: '/api/user' },
    cause: error
  })
});

if (error) {
  console.error(error);
} else {
  console.log("User:", data);
}
```