### PR TITLE
refactor: replace epicenter symlinks with npx skills managed copies

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,1 +1,0 @@
-../../epicenter/.agents/skills

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,1 +1,0 @@
-../.agents/skills

--- a/.claude/skills/control-flow/SKILL.md
+++ b/.claude/skills/control-flow/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: control-flow
+description: Human-readable control flow patterns for early returns, guard clauses, and linearizing nested logic. Use when refactoring nested conditionals, replacing try-catch with linear flow, or restructuring decision logic.
+---
+
+# Human-Readable Control Flow
+
+When refactoring complex control flow, mirror natural human reasoning patterns:
+
+1. **Ask the human question first**: "Can I use what I already have?" -> early return for happy path
+2. **Assess the situation**: "What's my current state and what do I need to do?" -> clear, mutually exclusive conditions
+3. **Take action**: "Get what I need" -> consolidated logic at the end
+4. **Use natural language variables**: `isUsingNavigator`, `isUsingLocalTranscription`, `needsOldFileCleanup`: names that read like thoughts
+5. **Avoid artificial constructs**: No nested conditions that don't match how humans actually think through problems
+
+Transform this: nested conditionals with duplicated logic
+Into this: linear flow that mirrors human decision-making
+
+## Example: Early Returns with Natural Language Variables
+
+```typescript
+// From apps/whispering/src/routes/(app)/_layout-utils/check-ffmpeg.ts
+
+export async function checkFfmpegRecordingMethodCompatibility() {
+	if (!window.__TAURI_INTERNALS__) return;
+
+	// Only check if FFmpeg recording method is selected
+	if (settings.value['recording.method'] !== 'ffmpeg') return;
+
+	const { data: ffmpegInstalled } =
+		await rpc.ffmpeg.checkFfmpegInstalled.ensure();
+	if (ffmpegInstalled) return; // FFmpeg is installed, all good
+
+	// FFmpeg recording method selected but not installed
+	toast.warning('FFmpeg Required for FFmpeg Recording Method', {
+		// ... toast content
+	});
+}
+```
+
+## Example: Natural Language Booleans
+
+```typescript
+// From apps/whispering/src/routes/(app)/_layout-utils/check-ffmpeg.ts
+
+const isUsingNavigator = settings.value['recording.method'] === 'navigator';
+const isUsingLocalTranscription =
+	settings.value['transcription.selectedTranscriptionService'] ===
+		'whispercpp' ||
+	settings.value['transcription.selectedTranscriptionService'] === 'parakeet';
+
+return isUsingNavigator && isUsingLocalTranscription && !isFFmpegInstalled;
+```
+
+## Example: Cleanup Check with Comment
+
+```typescript
+// From packages/epicenter/src/indexes/markdown/markdown-index.ts
+
+/**
+ * This is checking if there's an old filename AND if it's different
+ * from the new one. It's essentially checking: "has the filename
+ * changed?" and "do we need to clean up the old file?"
+ */
+const needsOldFileCleanup = oldFilename && oldFilename !== filename;
+if (needsOldFileCleanup) {
+	const oldFilePath = path.join(tableConfig.directory, oldFilename);
+	await deleteMarkdownFile({ filePath: oldFilePath });
+	tracking[table.name]!.deleteByFilename({ filename: oldFilename });
+}
+```
+
+## Example: Linearizing try-catch into Guard + Happy Path
+
+try-catch blocks create a nested, two-branch structure: the try body and the catch body. When only one call inside the try can actually throw, replace the try-catch with a guarded call + early return so the code reads top-to-bottom.
+
+Before (nested, mixed throw/return):
+
+```typescript
+async ({ body, status }) => {
+	const adapter = createAdapter(body.provider);
+
+	try {
+		const stream = chat({ adapter, messages: body.messages });
+		return toServerSentEventsResponse(stream);
+	} catch (error) {
+		if (error instanceof Error && error.name === 'AbortError') {
+			throw status(499, 'Client closed request');
+		}
+		const message = error instanceof Error ? error.message : 'Unknown error';
+		throw status('Bad Gateway', `Provider error: ${message}`);
+	}
+};
+```
+
+After (linear, consistent returns):
+
+```typescript
+async ({ body, status }) => {
+	const adapter = createAdapter(body.provider);
+
+	const { data: stream, error: chatError } = trySync({
+		try: () => chat({ adapter, messages: body.messages }),
+		catch: (e) => Err(e instanceof Error ? e : new Error(String(e))),
+	});
+
+	if (chatError) {
+		if (chatError.name === 'AbortError') {
+			return status(499, 'Client closed request');
+		}
+		return status('Bad Gateway', `Provider error: ${chatError.message}`);
+	}
+
+	return toServerSentEventsResponse(stream);
+};
+```
+
+The transformation follows the same human reasoning pattern:
+
+1. **Try the risky thing** — wrap only what can fail
+2. **Check if it failed** — early return with the appropriate error
+3. **Continue with the happy path** — the rest of the function assumes success
+
+This eliminates the nesting, makes `return` vs `throw` consistent, and separates the error boundary from the safe code that follows it.
+
+## Example: Sequential Guards in a Handler
+
+When a handler has multiple failure points, each guard follows the same pattern: do the thing, check the result, return early or continue.
+
+```typescript
+async ({ body, status }) => {
+	// Guard 1: validate input
+	if (!isSupportedProvider(body.provider)) {
+		return status('Bad Request', `Unsupported provider: ${body.provider}`);
+	}
+
+	// Guard 2: resolve dependency
+	const apiKey = resolveApiKey(body.provider, headers['x-api-key']);
+	if (!apiKey) {
+		return status('Unauthorized', 'Missing API key');
+	}
+
+	// Guard 3: risky operation
+	const { data: stream, error } = trySync({
+		try: () => chat({ adapter: createAdapter(body.provider, apiKey) }),
+		catch: (e) => Err(e instanceof Error ? e : new Error(String(e))),
+	});
+	if (error) return status('Bad Gateway', error.message);
+
+	// Happy path — all guards passed
+	return toServerSentEventsResponse(stream);
+};
+```
+
+Every guard has the same shape: check → return early on failure. The happy path accumulates at the bottom. Reading top-to-bottom, you see every way the function can fail before you see the success case.

--- a/.claude/skills/define-errors/SKILL.md
+++ b/.claude/skills/define-errors/SKILL.md
@@ -1,0 +1,244 @@
+---
+name: define-errors
+description: How to define and use defineErrors from wellcrafted. Use when creating new error types, updating error definitions, or reviewing error patterns. Covers variant factories, extractErrorMessage for cause, InferErrors/InferError for types, and call site patterns.
+metadata:
+  author: epicenter
+  version: '3.0'
+---
+
+# defineErrors
+
+## Import
+
+```typescript
+import {
+  defineErrors,
+  extractErrorMessage,
+  type InferErrors,
+  type InferError,
+} from 'wellcrafted/error';
+```
+
+## Core Rules
+
+1. All variants for a domain live in **one `defineErrors` call** — never spread them across multiple calls
+2. The factory function **returns `{ message, ...fields }`** — that is the entire API; no `.withMessage()`, `.withContext()`, or `.withCause()` chains
+3. **`cause: unknown`** is just a field like any other — accept it in the input and forward it in the return object
+4. **Call `extractErrorMessage(cause)` inside the factory**, never at the call site
+5. Each call like `MyError.Variant({ ... })` **returns `Err(...)` automatically** — no separate `FooErr` pair
+6. **Shadow the const with a same-name type** using `InferErrors` — `const FooError` / `type FooError`
+7. Use `InferError<typeof FooError.Variant>` to extract a single variant's type when needed
+8. **Variant names describe the specific failure mode** — never use generic names like `Service`, `Error`, or `Failed`
+9. Aim for 2–5 variants per domain, each named by failure mode
+
+## Patterns
+
+### 1. Simple variant — no input, static message
+
+```typescript
+export const RecorderError = defineErrors({
+  AlreadyRecording: () => ({
+    message: 'A recording is already in progress',
+  }),
+});
+export type RecorderError = InferErrors<typeof RecorderError>;
+
+// Call site
+return RecorderError.AlreadyRecording();
+```
+
+### 2. Variant with structured fields — message computed from input
+
+```typescript
+export const DbError = defineErrors({
+  NotFound: ({ table, id }: { table: string; id: string }) => ({
+    message: `${table} '${id}' not found`,
+    table,
+    id,
+  }),
+});
+export type DbError = InferErrors<typeof DbError>;
+
+// Call site
+return DbError.NotFound({ table: 'users', id: '123' });
+// error.message → "users '123' not found"
+// error.table   → "users"
+// error.id      → "123"
+```
+
+### 3. Variant with cause — extractErrorMessage inside the factory
+
+```typescript
+import { extractErrorMessage } from 'wellcrafted/error';
+
+export const FfmpegError = defineErrors({
+  CompressFailed: ({ cause }: { cause: unknown }) => ({
+    message: `Failed to compress audio: ${extractErrorMessage(cause)}`,
+    cause,
+  }),
+  VerifyFailed: ({ cause }: { cause: unknown }) => ({
+    message: `Failed to verify temp file: ${extractErrorMessage(cause)}`,
+    cause,
+  }),
+});
+export type FfmpegError = InferErrors<typeof FfmpegError>;
+
+// Call site — pass the raw caught error, never call extractErrorMessage here
+catch: (error) => FfmpegError.CompressFailed({ cause: error }),
+```
+
+### 4. Multiple variants in one object — discriminated union built-in
+
+```typescript
+export const DeviceStreamError = defineErrors({
+  PermissionDenied: ({ cause }: { cause: unknown }) => ({
+    message: `Microphone permission denied. ${extractErrorMessage(cause)}`,
+    cause,
+  }),
+  DeviceConnectionFailed: ({
+    deviceId,
+    cause,
+  }: {
+    deviceId: string;
+    cause: unknown;
+  }) => ({
+    message: `Unable to connect to device '${deviceId}'. ${extractErrorMessage(cause)}`,
+    deviceId,
+    cause,
+  }),
+  NoDevicesFound: () => ({
+    message: "No microphones found. Check your connections and try again.",
+  }),
+});
+export type DeviceStreamError = InferErrors<typeof DeviceStreamError>;
+// DeviceStreamError is automatically the union of all three variants
+
+// Extracting a single variant type
+type NoDevicesFoundError = InferError<typeof DeviceStreamError.NoDevicesFound>;
+```
+
+### 5. Domain errors with specific operation failures
+
+```typescript
+export const FsError = defineErrors({
+  ReadFailed: ({ path, cause }: { path: string; cause: unknown }) => ({
+    message: `Failed to read '${path}': ${extractErrorMessage(cause)}`,
+    path,
+    cause,
+  }),
+  WriteFailed: ({ path, cause }: { path: string; cause: unknown }) => ({
+    message: `Failed to write '${path}': ${extractErrorMessage(cause)}`,
+    path,
+    cause,
+  }),
+  DeleteFailed: ({ path, cause }: { path: string; cause: unknown }) => ({
+    message: `Failed to delete '${path}': ${extractErrorMessage(cause)}`,
+    path,
+    cause,
+  }),
+});
+export type FsError = InferErrors<typeof FsError>;
+
+// Call site
+return FsError.ReadFailed({ path: '/tmp/foo.txt', cause: error });
+```
+
+## Type Extraction
+
+```typescript
+// Full union type for all variants
+type HttpError = InferErrors<typeof HttpError>;
+
+// Single variant type
+type ConnectionError = InferError<typeof HttpError.Connection>;
+```
+
+## Anti-Patterns
+
+```typescript
+// WRONG — old createTaggedError API
+import { createTaggedError } from 'wellcrafted/error';
+const { FooError, FooErr } = createTaggedError('FooError')
+  .withContext<{ id: string }>()
+  .withMessage(({ context }) => `Not found: ${context.id}`);
+
+// WRONG — calling extractErrorMessage at the call site
+catch: (error) => MyError.Failed({ message: extractErrorMessage(error) });
+// CORRECT — pass raw cause, call extractErrorMessage inside the factory
+catch: (error) => MyError.Failed({ cause: error });
+
+// WRONG — one defineErrors per variant (defeats the namespace grouping)
+const BusyError = defineErrors({ BusyError: () => ({ message: 'Busy' }) });
+const PermError = defineErrors({ PermError: () => ({ message: 'No perm' }) });
+// CORRECT — all variants for a domain in one call
+const RecorderError = defineErrors({
+  Busy: () => ({ message: 'A recording is already in progress' }),
+  PermissionDenied: () => ({ message: 'Microphone permission denied' }),
+});
+
+// WRONG — using ReturnType instead of InferErrors
+type FooError = ReturnType<typeof FooError>;
+// CORRECT
+type FooError = InferErrors<typeof FooError>;
+
+// WRONG — using separate Err/FooErr pair (old API)
+FooErr({ context: { id: '1' } });
+// CORRECT — each variant call returns Err(...) automatically
+FooError.NotFound({ id: '1' });
+
+// WRONG — generic "Service" variant name (says nothing about the failure mode)
+const RecorderError = defineErrors({
+  Service: ({ message }: { message: string }) => ({ message }),
+});
+// RecorderError.Service({ message: '...' }) — "Service" is not a failure mode
+// CORRECT — name each variant by what actually went wrong
+const RecorderError = defineErrors({
+  AlreadyRecording: () => ({ message: 'A recording is already in progress' }),
+  PermissionDenied: ({ cause }: { cause: unknown }) => ({
+    message: `Microphone permission denied. ${extractErrorMessage(cause)}`,
+    cause,
+  }),
+  DeviceNotFound: ({ deviceId }: { deviceId: string }) => ({
+    message: `Device not found: ${deviceId}`,
+    deviceId,
+  }),
+});
+
+// WRONG — generic catch-all with operation string (hides failure modes behind a parameter)
+const FfmpegError = defineErrors({
+  Service: ({ operation, cause }: { operation: string; cause: unknown }) => ({
+    message: `Failed to ${operation}: ${extractErrorMessage(cause)}`,
+    operation,
+    cause,
+  }),
+});
+// FfmpegError.Service({ operation: 'compress audio', cause }) — variant name is meaningless
+// CORRECT — each operation is its own variant
+const FfmpegError = defineErrors({
+  CompressFailed: ({ cause }: { cause: unknown }) => ({
+    message: `Failed to compress audio: ${extractErrorMessage(cause)}`,
+    cause,
+  }),
+  VerifyFailed: ({ cause }: { cause: unknown }) => ({
+    message: `Failed to verify temp file: ${extractErrorMessage(cause)}`,
+    cause,
+  }),
+});
+
+// WRONG — monolithic single-variant error for a domain with many failure modes
+const RecorderError = defineErrors({
+  Error: ({ message }: { message: string }) => ({ message }), // Too vague
+});
+// CORRECT — split by failure mode
+const RecorderError = defineErrors({
+  AlreadyRecording: () => ({ message: 'A recording is already in progress' }),
+  InitFailed: ({ cause }: { cause: unknown }) => ({
+    message: `Failed to initialize recorder: ${extractErrorMessage(cause)}`,
+    cause,
+  }),
+  StreamAcquisition: ({ cause }: { cause: unknown }) => ({
+    message: `Failed to acquire recording stream: ${extractErrorMessage(cause)}`,
+    cause,
+  }),
+});
+```

--- a/.claude/skills/documentation/SKILL.md
+++ b/.claude/skills/documentation/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: documentation
+description: In-code documentation, folder READMEs, and code comments. Use when writing README.md files, JSDoc comments, or explaining code organization.
+---
+
+# Documentation
+
+Follow [writing-voice](../writing-voice/SKILL.md) for tone.
+
+Documentation explains **why**, not **what**. Users can read code to see what it does. They need you to explain the reasoning.
+
+## Folder READMEs
+
+Primary job: explain **why** this folder exists and the mental model.
+
+### Can Include
+
+- ASCII art diagrams for complex relationships
+- Overview of key exports or entry points
+- Brief file descriptions IF they add context beyond the filename
+- Relationships to other folders
+
+### Avoid
+
+- Exhaustive file listings that just duplicate `ls`
+- Descriptions that repeat the filename ("auth.ts - authentication")
+- Implementation details better expressed in code
+
+### Good
+
+````markdown
+# Converters
+
+Transform field schemas into format-specific representations.
+
+```
+┌─────────────┐     ┌──────────────┐
+│ Field Schema│────▶│  to-arktype  │────▶ Runtime validation
+└─────────────┘     ├──────────────┤
+                    │  to-drizzle  │────▶ SQLite columns
+                    └──────────────┘
+```
+
+Field schemas are pure JSON Schema objects with `x-component` hints. Each converter takes the same input and produces output for a specific consumer.
+````
+
+### Bad
+
+```markdown
+# Converters
+
+- `to-arktype.ts` - Converts to ArkType
+- `to-drizzle.ts` - Converts to Drizzle
+- `index.ts` - Exports
+```
+
+The bad example just lists files without explaining the pattern or when to add new converters.
+
+## JSDoc Comments
+
+JSDoc explains **when and why** to use something, not just what it does.
+
+### Good
+
+````typescript
+/**
+ * Get all table helpers as an array.
+ *
+ * Useful for providers and indexes that need to iterate over all tables.
+ * Returns only the table helpers, excluding utility methods like `clearAll`.
+ *
+ * @example
+ * ```typescript
+ * for (const table of tables.defined()) {
+ *   console.log(table.name, table.count());
+ * }
+ * ```
+ */
+defined() { ... }
+````
+
+### Bad
+
+```typescript
+/** Returns all table helpers as an array. */
+defined() { ... }
+```
+
+### Rules
+
+- Include `@example` blocks with realistic usage
+- Explain WHEN to use it, not just WHAT it does
+- Document non-obvious behavior or edge cases
+- Public APIs get detailed docs; internal helpers can be minimal
+
+## Code Comments
+
+Comments explain **why**, not **what**.
+
+### Good
+
+```typescript
+// Y.Doc clientIDs are random 32-bit integers, so we can't rely on ordering.
+// Use timestamps from the entries themselves for deterministic sorting.
+const sorted = entries.sort((a, b) => a.timestamp - b.timestamp);
+```
+
+### Bad
+
+```typescript
+// Sort the entries
+const sorted = entries.sort((a, b) => a.timestamp - b.timestamp);
+```
+
+### Rules
+
+- If the code is clear, don't comment it
+- Comment the "why" when it's not obvious
+- Comment workarounds with links to issues/docs
+- Delete commented-out code; that's what git is for

--- a/.claude/skills/error-handling/SKILL.md
+++ b/.claude/skills/error-handling/SKILL.md
@@ -1,0 +1,402 @@
+---
+name: error-handling
+description: Error handling patterns using wellcrafted trySync and tryAsync. Use when writing or reviewing try-catch blocks, refactoring try-catch to linear control flow, working with Result types, or returning HTTP error responses from route handlers.
+metadata:
+  author: epicenter
+  version: '1.2'
+---
+
+# Error Handling with wellcrafted trySync and tryAsync
+
+## Use trySync/tryAsync Instead of try-catch for Graceful Error Handling
+
+When handling errors that can be gracefully recovered from, use `trySync` (for synchronous code) or `tryAsync` (for asynchronous code) from wellcrafted instead of traditional try-catch blocks. This provides better type safety and explicit error handling.
+
+> **Related Skills**: See `services-layer` skill for `defineErrors` patterns and service architecture. See `query-layer` skill for error transformation to `WhisperingError`.
+
+### The Pattern
+
+```typescript
+import { trySync, tryAsync, Ok, Err } from 'wellcrafted/result';
+
+// SYNCHRONOUS: Use trySync for sync operations
+const { data, error } = trySync({
+	try: () => {
+		const parsed = JSON.parse(jsonString);
+		return validateData(parsed); // Automatically wrapped in Ok()
+	},
+	catch: (e) => {
+		// Gracefully handle parsing/validation errors
+		console.log('Using default configuration');
+		return Ok(defaultConfig); // Return Ok with fallback
+	},
+});
+
+// ASYNCHRONOUS: Use tryAsync for async operations
+await tryAsync({
+	try: async () => {
+		const child = new Child(session.pid);
+		await child.kill();
+		console.log(`Process killed successfully`);
+	},
+	catch: (e) => {
+		// Gracefully handle the error
+		console.log(`Process was already terminated`);
+		return Ok(undefined); // Return Ok(undefined) for void functions
+	},
+});
+
+// Both support the same catch patterns
+const syncResult = trySync({
+	try: () => riskyOperation(),
+	catch: (error) => {
+		// For recoverable errors, return Ok with fallback value
+		return Ok('fallback-value');
+		// For unrecoverable errors, pass the raw cause — the constructor handles extractErrorMessage
+		return CompletionError.ConnectionFailed({ cause: error });
+	},
+});
+```
+
+### Key Rules
+
+1. **Choose the right function** - Use `trySync` for synchronous code, `tryAsync` for asynchronous code
+2. **Always await tryAsync** - Unlike try-catch, tryAsync returns a Promise and must be awaited
+3. **trySync returns immediately** - No await needed for synchronous operations
+4. **Match return types** - If the try block returns `T`, the catch should return `Ok<T>` for graceful handling
+5. **Use Ok(undefined) for void** - When the function returns void, use `Ok(undefined)` in the catch
+6. **Return Err for propagation** - Use custom error constructors that return `Err` when you want to propagate the error
+7. **Transform cause in the constructor, not the call site** - When wrapping a caught error, pass the raw error as `cause: unknown` and let the `defineErrors` constructor call `extractErrorMessage(cause)` inside its message template. Don't call `extractErrorMessage` at the call site. This centralizes message extraction where the message is composed:
+
+```typescript
+// ✅ GOOD: cause: error at call site, extractErrorMessage in constructor
+catch: (error) => CompletionError.ConnectionFailed({ cause: error })
+
+// ❌ BAD: extractErrorMessage at call site, string passed to constructor
+catch: (error) => CompletionError.ConnectionFailed({ underlyingError: extractErrorMessage(error) })
+```
+
+8. **CRITICAL: Wrap destructured errors with Err()** - When you destructure `{ data, error }` from tryAsync/trySync, the `error` variable is the raw error value, NOT wrapped in `Err`. You must wrap it before returning:
+
+```typescript
+// WRONG - error is just the raw error value, not a Result
+const { data, error } = await tryAsync({...});
+if (error) return error; // TYPE ERROR: Returns raw error, not Result
+
+// CORRECT - wrap with Err() to return a proper Result
+const { data, error } = await tryAsync({...});
+if (error) return Err(error); // Returns Err<CustomError>
+```
+
+This is different from returning the entire result object:
+
+```typescript
+// This is also correct - userResult is already a Result type
+const userResult = await tryAsync({...});
+if (userResult.error) return userResult; // Returns the full Result
+```
+
+### Examples
+
+```typescript
+// SYNCHRONOUS: JSON parsing with fallback
+const { data: config } = trySync({
+	try: () => JSON.parse(configString),
+	catch: (e) => {
+		console.log('Invalid config, using defaults');
+		return Ok({ theme: 'dark', autoSave: true });
+	},
+});
+
+// SYNCHRONOUS: File system check
+const { data: exists } = trySync({
+	try: () => fs.existsSync(path),
+	catch: () => Ok(false), // Assume doesn't exist if check fails
+});
+
+// ASYNCHRONOUS: Graceful process termination
+await tryAsync({
+	try: async () => {
+		await process.kill();
+	},
+	catch: (e) => {
+		console.log('Process already dead, continuing...');
+		return Ok(undefined);
+	},
+});
+
+// ASYNCHRONOUS: File operations with fallback
+const { data: content } = await tryAsync({
+	try: () => readFile(path),
+	catch: (e) => {
+		console.log('File not found, using default');
+		return Ok('default content');
+	},
+});
+
+// EITHER: Error propagation (works with both)
+// Pass the raw caught error as cause — the defineErrors constructor calls extractErrorMessage
+const { data, error } = await tryAsync({
+	try: () => criticalOperation(),
+	catch: (error) =>
+		CompletionError.ConnectionFailed({ cause: error }),
+});
+if (error) return Err(error);
+```
+
+### When to Use trySync vs tryAsync vs try-catch
+
+- **Use trySync when**:
+  - Working with synchronous operations (JSON parsing, validation, calculations)
+  - You need immediate Result types without promises
+  - Handling errors in synchronous utility functions
+  - Working with filesystem sync operations
+
+- **Use tryAsync when**:
+  - Working with async/await operations
+  - Making network requests or database calls
+  - Reading/writing files asynchronously
+  - Any operation that returns a Promise
+
+- **Use traditional try-catch when**:
+  - In module-level initialization code where you can't await
+  - For simple fire-and-forget operations
+  - When you're outside of a function context
+  - When integrating with code that expects thrown exceptions
+
+## Wrapping Patterns: Minimal vs Extended
+
+### The Minimal Wrapping Principle
+
+**Wrap only the specific operation that can fail.** This captures the error boundary precisely and makes code easier to reason about.
+
+```typescript
+// ✅ GOOD: Wrap only the risky operation, pass raw cause to constructor
+const { data: stream, error: streamError } = await tryAsync({
+	try: () => navigator.mediaDevices.getUserMedia({ audio: true }),
+	catch: (error) =>
+		DeviceStreamError.PermissionDenied({ cause: error }),
+});
+
+if (streamError) return Err(streamError);
+
+// Continue with non-throwing operations
+const mediaRecorder = new MediaRecorder(stream);
+mediaRecorder.start();
+```
+
+```typescript
+// ❌ BAD: Wrapping too much code
+const { data, error } = await tryAsync({
+	try: async () => {
+		const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+		const mediaRecorder = new MediaRecorder(stream);
+		mediaRecorder.start();
+		await someOtherAsyncCall();
+		return processResults();
+	},
+	catch: (error) => Err(error), // Too vague! No specific error type
+});
+```
+
+### The Immediate Return Pattern
+
+**Return errors immediately after checking.** This creates clear control flow and prevents error nesting.
+
+```typescript
+// ✅ GOOD: Check and return immediately
+const { data: devices, error: enumerateError } = await enumerateDevices();
+if (enumerateError) return Err(enumerateError);
+
+const { data: stream, error: streamError } = await getStreamForDevice(
+	devices[0],
+);
+if (streamError) return Err(streamError);
+
+// Happy path continues cleanly
+return Ok(stream);
+```
+
+```typescript
+// ❌ BAD: Nested error handling
+const { data: devices, error: enumerateError } = await enumerateDevices();
+if (!enumerateError) {
+	const { data: stream, error: streamError } = await getStreamForDevice(
+		devices[0],
+	);
+	if (!streamError) {
+		return Ok(stream);
+	} else {
+		return Err(streamError);
+	}
+} else {
+	return Err(enumerateError);
+}
+```
+
+### When to Extend the Try Block
+
+Sometimes it makes sense to include multiple operations in a single try block:
+
+1. **Atomic operations** - When operations must succeed or fail together
+2. **Same error type** - When all operations produce the same error category
+3. **Cleanup logic** - When you need to clean up on any failure
+
+```typescript
+// Extended block is appropriate here - all operations are part of "starting recording"
+const { data: mediaRecorder, error: recorderError } = trySync({
+	try: () => {
+		const recorder = new MediaRecorder(stream, { bitsPerSecond: bitrate });
+		recorder.addEventListener('dataavailable', handleData);
+		recorder.start(TIMESLICE_MS);
+		return recorder;
+	},
+	catch: (error) =>
+		RecorderError.InitFailed({ cause: error }),
+});
+```
+
+### Real-World Examples from the Codebase
+
+**Minimal wrap with immediate return:**
+
+```typescript
+// From device-stream.ts — cause: error at call site, extractErrorMessage in constructor
+async function getStreamForDeviceIdentifier(
+	deviceIdentifier: DeviceIdentifier,
+) {
+	return tryAsync({
+		try: async () => {
+			const stream = await navigator.mediaDevices.getUserMedia({
+				audio: { ...constraints, deviceId: { exact: deviceIdentifier } },
+			});
+			return stream;
+		},
+		catch: (error) =>
+			DeviceStreamError.DeviceConnectionFailed({ deviceId: deviceIdentifier, cause: error }),
+	});
+}
+```
+
+**Multiple minimal wraps with immediate returns:**
+
+```typescript
+// From navigator.ts
+startRecording: async (params, { sendStatus }) => {
+  if (activeRecording) {
+    return RecorderError.AlreadyRecording();
+  }
+
+  // First try block - get stream
+  const { data: streamResult, error: acquireStreamError } =
+    await getRecordingStream({ selectedDeviceId, sendStatus });
+  if (acquireStreamError) return Err(acquireStreamError);
+
+  const { stream, deviceOutcome } = streamResult;
+
+  // Second try block - create recorder
+  const { data: mediaRecorder, error: recorderError } = trySync({
+    try: () => new MediaRecorder(stream, { bitsPerSecond: bitrate }),
+    catch: (error) => RecorderError.InitFailed({ cause: error }),
+  });
+
+  if (recorderError) {
+    cleanupRecordingStream(stream);  // Cleanup on failure
+    return Err(recorderError);
+  }
+
+  // Happy path continues...
+  mediaRecorder.start(TIMESLICE_MS);
+  return Ok(deviceOutcome);
+},
+```
+
+### Summary: Wrapping Guidelines
+
+| Scenario                                     | Approach                                          |
+| -------------------------------------------- | ------------------------------------------------- |
+| Single risky operation                       | Wrap just that operation                          |
+| Sequential operations                        | Wrap each separately, return immediately on error |
+| Atomic operations that must succeed together | Wrap together in one block                        |
+| Different error types needed                 | Separate blocks with appropriate error types      |
+| Need cleanup on failure                      | Wrap, check error, cleanup if needed, return      |
+
+**The goal**: Each `trySync`/`tryAsync` block should represent a single "unit of failure" with a specific, descriptive error message.
+
+## Using trySync/tryAsync in HTTP Handlers
+
+Not all error handling involves propagating `Result` types up a service chain. In HTTP route handlers (Elysia, Express, SvelteKit, etc.), you often want to convert errors directly into HTTP status responses. The same trySync/tryAsync patterns apply; you just return a status response instead of `Err(...)`.
+
+### The Pattern: trySync → early return with status
+
+```typescript
+// From packages/server/src/ai/plugin.ts — Elysia route handler
+async ({ body, headers, status }) => {
+	// Validation guards use return status() directly
+	if (!isSupportedProvider(provider)) {
+		return status('Bad Request', `Unsupported provider: ${provider}`);
+	}
+
+	// Wrap only the call that can throw — chat() may fail on bad adapter config.
+	// toServerSentEventsResponse() is pure construction and never throws.
+	const { data: stream, error: chatError } = trySync({
+		try: () =>
+			chat({
+				adapter,
+				messages,
+				abortController,
+			}),
+		catch: (e) => Err(e instanceof Error ? e : new Error(String(e))),
+	});
+
+	if (chatError) {
+		if (chatError.name === 'AbortError' || abortController.signal.aborted) {
+			return status(499, 'Client closed request');
+		}
+		return status('Bad Gateway', `Provider error: ${chatError.message}`);
+	}
+
+	// Happy path — stream is guaranteed non-null after the error check
+	return toServerSentEventsResponse(stream, { abortController });
+};
+```
+
+### Key Differences from Service-Layer Usage
+
+| Service layer                                  | HTTP handler                                                       |
+| ---------------------------------------------- | ------------------------------------------------------------------ |
+| `catch: (e) => ServiceErr({ message: '...' })` | `catch: (e) => Err(e instanceof Error ? e : new Error(String(e)))` |
+| `if (error) return Err(error)`                 | `if (error) return status(502, error.message)`                     |
+| Propagates typed errors up the chain           | Converts errors to HTTP responses immediately                      |
+| Caller decides what to do with the error       | Handler IS the final caller                                        |
+
+In HTTP handlers, you're the last stop. There's no caller above you to propagate to; you convert the error into a response and return it. The trySync pattern still gives you linear control flow and surgical error boundaries—you just use `return status(...)` instead of `return Err(...)`.
+
+### Refactoring try-catch to trySync in Handlers
+
+Before (try-catch with throw):
+
+```typescript
+try {
+	const result = riskyCall();
+	return buildResponse(result);
+} catch (error) {
+	const message = error instanceof Error ? error.message : 'Unknown error';
+	throw status(500, message);
+}
+```
+
+After (trySync with early return):
+
+```typescript
+const { data: result, error } = trySync({
+	try: () => riskyCall(),
+	catch: (e) => Err(e instanceof Error ? e : new Error(String(e))),
+});
+
+if (error) return status(500, error.message);
+
+return buildResponse(result);
+```
+
+The trySync version wraps only the risky call, uses `return` consistently (no `throw` vs `return` mismatch), and keeps the happy path at the bottom of the function.

--- a/.claude/skills/factory-function-composition/SKILL.md
+++ b/.claude/skills/factory-function-composition/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: factory-function-composition
+description: Apply factory function patterns to compose clients and services with proper separation of concerns. Use when creating functions that depend on external clients, wrapping resources with domain-specific methods, or refactoring code that mixes client/service/method options together.
+metadata:
+  author: epicenter
+  version: '1.0'
+---
+
+# Factory Function Composition
+
+This skill helps you apply factory function patterns for clean dependency injection and function composition in TypeScript.
+
+## When to Apply This Skill
+
+Use this pattern when you see:
+
+- A function that takes a client/resource as its first argument
+- Options from different layers (client, service, method) mixed together
+- Client creation happening inside functions that shouldn't own it
+- Functions that are hard to test because they create their own dependencies
+
+## The Universal Signature
+
+**Every factory function follows this signature:**
+
+```typescript
+function createSomething(dependencies, options?) {
+	return {
+		/* methods */
+	};
+}
+```
+
+- **First argument**: Always the resource(s). Either a single client or a destructured object of multiple dependencies.
+- **Second argument**: Optional configuration specific to this factory. Never client config—that belongs at client creation.
+
+Two arguments max. First is resources, second is config. No exceptions.
+
+## The Core Pattern
+
+```typescript
+// Single dependency
+function createService(client, options = {}) {
+	return {
+		method(methodOptions) {
+			// Uses client, options, and methodOptions
+		},
+	};
+}
+
+// Multiple dependencies
+function createService({ db, cache }, options = {}) {
+	return {
+		method(methodOptions) {
+			// Uses db, cache, options, and methodOptions
+		},
+	};
+}
+
+// Usage
+const client = createClient(clientOptions);
+const service = createService(client, serviceOptions);
+service.method(methodOptions);
+```
+
+## Key Principles
+
+1. **Client configuration belongs at client creation time** — don't pipe clientOptions through your factory
+2. **Each layer has its own options** — client, service, and method options stay separate
+3. **Dependencies come first** — factory functions take dependencies as the first argument
+4. **Return objects with methods** — not standalone functions that need the resource passed in
+
+## Recognizing the Anti-Patterns
+
+### Anti-Pattern 1: Function takes client as first argument
+
+```typescript
+// Bad
+function doSomething(client, options) { ... }
+doSomething(client, options);
+
+// Good
+const service = createService(client);
+service.doSomething(options);
+```
+
+### Anti-Pattern 2: Client creation hidden inside
+
+```typescript
+// Bad
+function doSomething(clientOptions, methodOptions) {
+	const client = createClient(clientOptions); // Hidden!
+	// ...
+}
+
+// Good
+const client = createClient(clientOptions);
+const service = createService(client);
+service.doSomething(methodOptions);
+```
+
+### Anti-Pattern 3: Mixed options blob
+
+```typescript
+// Bad
+doSomething({
+	timeout: 5000, // Client option
+	retries: 3, // Client option
+	endpoint: '/users', // Method option
+	payload: data, // Method option
+});
+
+// Good
+const client = createClient({ timeout: 5000, retries: 3 });
+const service = createService(client);
+service.doSomething({ endpoint: '/users', payload: data });
+```
+
+### Anti-Pattern 4: Multiple layers hidden
+
+```typescript
+// Bad
+function doSomething(clientOptions, serviceOptions, methodOptions) {
+	const client = createClient(clientOptions);
+	const service = createService(client, serviceOptions);
+	return service.method(methodOptions);
+}
+
+// Good — each layer visible and configurable
+const client = createClient(clientOptions);
+const service = createService(client, serviceOptions);
+service.method(methodOptions);
+```
+
+## Multiple Dependencies
+
+When your service needs multiple clients:
+
+```typescript
+function createService(
+	{ db, cache, http }, // Dependencies as destructured object
+	options = {}, // Service options
+) {
+	return {
+		method(methodOptions) {
+			// Uses db, cache, http
+		},
+	};
+}
+
+// Usage
+const db = createDbConnection(dbOptions);
+const cache = createCacheClient(cacheOptions);
+const http = createHttpClient(httpOptions);
+
+const service = createService({ db, cache, http }, serviceOptions);
+service.method(methodOptions);
+```
+
+## The Canonical Internal Shape
+
+The previous sections cover the external signature—`(deps, options?) → return { methods }`. This section covers what goes *inside* the function body. Every factory function follows a four-zone ordering:
+
+```typescript
+// Option A — destructure in the signature (preferred for small dep lists)
+function createSomething({ db, cache }: Deps, options?) {
+	const maxRetries = options?.maxRetries ?? 3;
+	// ...
+}
+
+// Option B — destructure in zone 1 (fine when you also need the deps object itself)
+function createSomething(deps: Deps, options?) {
+	const { db, cache } = deps;
+	const maxRetries = options?.maxRetries ?? 3;
+	// ...
+}
+```
+
+Both are valid. The point is that by the time you reach zone 2, all dependencies and config are bound to `const` names. The four zones:
+
+```typescript
+function createSomething({ db, cache }, options?) {
+	// Zone 1 — Immutable state (const from deps/options)
+	const maxRetries = options?.maxRetries ?? 3;
+
+	// Zone 2 — Mutable state (let declarations)
+	let connectionCount = 0;
+	let lastError: Error | null = null;
+
+	// Zone 3 — Private helpers
+	function resetState() {
+		connectionCount = 0;
+		lastError = null;
+	}
+
+	// Zone 4 — Public API (always last)
+	return {
+		connect() { ... },
+		disconnect() { ... },
+		get errorCount() { return connectionCount; },
+	};
+}
+```
+
+Zones 1 and 2 can merge when there's little state. Zone 3 is empty for small factories. But the return object is always last—it's the complete public API.
+
+### The `this` Decision Rule
+
+Inside the return object, public methods sometimes need to call other public methods. Use `this.method()` for that—method shorthand gives proper `this` binding.
+
+If a function is called both by return-object methods *and* by pre-return initialization logic, it belongs in zone 3 (private helpers). Call it directly by name; no `this` needed.
+
+| Where the function lives | How to call it |
+|---|---|
+| Return object (zone 4) | `this.method()` from sibling methods |
+| Private helper (zone 3) | Direct call by name: `helperFn()` |
+| Both zones need it | Keep in zone 3, call by name everywhere |
+
+See [Closures Are Better Privacy Than Keywords](../../docs/articles/closures-are-better-privacy-than-keywords.md) for the full rationale and real codebase examples.
+
+## The Mental Model
+
+Think of it as a chain where each link:
+
+- Receives a resource from the previous link
+- Adds its own configuration
+- Produces something for the next link
+
+```
+createClient(...)  →  createService(client, ...)  →  service.method(...)
+     ↑                       ↑                            ↑
+ clientOptions          serviceOptions              methodOptions
+```
+
+## Benefits
+
+- **Testability**: Inject mock clients easily
+- **Reusability**: Share clients across multiple services
+- **Flexibility**: Configure each layer independently
+- **Clarity**: Clear ownership of configuration at each level
+
+## References
+
+See the full articles for more details:
+
+- [The Universal Factory Function Signature](../../docs/articles/universal-factory-signature.md) — signature explained in depth
+- [Stop Passing Clients as Arguments](../../docs/articles/stop-passing-clients-as-arguments.md) — practical guide
+- [The Factory Function Pattern](../../docs/articles/factory-function-pattern.md) — detailed explanation
+- [Factory Method Patterns](../../docs/articles/factory-method-patterns.md) — separating options and method patterns
+- [Closures Are Better Privacy Than Keywords](../../docs/articles/closures-are-better-privacy-than-keywords.md) — internal anatomy and why closures beat class keywords

--- a/.claude/skills/git/SKILL.md
+++ b/.claude/skills/git/SKILL.md
@@ -1,0 +1,571 @@
+---
+name: git
+description: Git commit and pull request guidelines using conventional commits. Use when creating commits, writing commit messages, creating PRs, or reviewing PR descriptions.
+---
+
+# Git Commit and Pull Request Guidelines
+
+## Conventional Commits Format
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Commit Types
+
+- `feat`: New features (correlates with MINOR in semantic versioning)
+- `fix`: Bug fixes (correlates with PATCH in semantic versioning)
+- `docs`: Documentation only changes
+- `refactor`: Code changes that neither fix bugs nor add features
+- `perf`: Performance improvements
+- `test`: Adding or modifying tests
+- `chore`: Maintenance tasks, dependency updates, etc.
+- `style`: Code style changes (formatting, missing semicolons, etc.)
+- `build`: Changes to build system or dependencies
+- `ci`: Changes to CI configuration files and scripts
+
+### Scope Guidelines
+
+- **Scope is OPTIONAL**: only add when it provides clarity
+- Use lowercase, placed in parentheses after type: `feat(transcription):`
+- Prefer specific component/module names over generic terms
+- Your current practice is good: component names (`EditRecordingDialog`), feature areas (`transcription`, `sound`)
+- Avoid overly generic scopes like `ui` or `backend` unless truly appropriate
+
+### When to Use Scope
+
+- When the change is localized to a specific component/module
+- When it helps distinguish between similar changes
+- When working in a large codebase with distinct areas
+
+### When NOT to Use Scope
+
+- When the change affects multiple areas equally
+- When the type alone is sufficiently descriptive
+- For small, obvious changes
+
+### Description Rules
+
+- Start with lowercase immediately after the colon and space
+- Use imperative mood ("add" not "added" or "adds")
+- No period at the end
+- Keep under 50-72 characters on first line
+
+### Breaking Changes
+
+- Add `!` after type/scope, before colon: `feat(api)!: change endpoint structure`
+- Include `BREAKING CHANGE:` in the footer with details
+- These trigger MAJOR version bumps in semantic versioning
+
+### Examples Following Your Style:
+
+- `feat(transcription): add model selection for OpenAI providers`
+- `fix(sound): resolve audio import paths in assets module`
+- `refactor(EditRecordingDialog): implement working copy pattern`
+- `docs(README): clarify cost comparison section`
+- `chore: update dependencies to latest versions`
+- `fix!: change default transcription API endpoint`
+
+## Commit Messages Best Practices
+
+### The "Why" is More Important Than the "What"
+
+The commit message subject line describes WHAT changed. The commit body explains WHY.
+
+**Good commit** (explains motivation):
+
+```
+fix(auth): prevent session timeout during file upload
+
+Users were getting logged out mid-upload on large files because the
+session refresh only triggered on navigation, not background activity.
+```
+
+**Bad commit** (only describes what):
+
+```
+fix(auth): add keepalive call to upload handler
+```
+
+The first commit tells future developers WHY the code exists. The second makes them dig through the code to understand the purpose.
+
+### Other Best Practices
+
+- NEVER include Claude Code or opencode watermarks or attribution
+- Each commit should represent a single, atomic change
+- Write commits for future developers (including yourself)
+- If you need more than one line to describe what you did, consider splitting the commit
+
+## Pull Request Guidelines
+
+### WHAT First, Then WHY
+
+Every PR description MUST open with a crisp one-sentence summary of WHAT changed, then immediately explain WHY. The WHAT grounds the reader; the WHY gives them the motivation.
+
+**Good PR opening**:
+
+> Redesigns the `createTaggedError` builder: flat `.withFields()` API replaces nested `.withContext()`/`.withCause()`, `.withMessage()` is optional and seals the message.
+>
+> Analysis of 321 error call sites revealed every error is always all-or-nothing on message ownership. The old API allowed overriding `.withMessage()` at the call site, which masked design problems rather than solving them.
+
+**Bad opening** (why without what):
+
+> Users were getting logged out mid-upload on large files. The session refresh only triggered on navigation, not during background activity like uploads.
+
+**Bad opening** (what without why):
+
+> This PR adds a keepalive call to the upload handler and updates the session refresh logic.
+
+The reader should understand WHAT changed before they understand WHY — but they need both.
+
+### Code Examples Are Mandatory for API Changes
+
+If the PR introduces or modifies APIs, you MUST include code examples showing how to use them. No exceptions.
+
+**What requires code examples:**
+
+- New functions, types, or exports
+- Changes to function signatures
+- New CLI commands or flags
+- New HTTP endpoints
+- Configuration changes
+
+**Good API PR** (shows the actual usage):
+
+```typescript
+// Define actions once
+const actions = {
+	posts: {
+		create: defineMutation({
+			input: type({ title: 'string' }),
+			handler: ({ title }) => client.tables.posts.create({ title }),
+		}),
+	},
+};
+
+// Pass to adapters - they generate CLI commands and HTTP routes
+const cli = createCLI(client, { actions });
+const server = createServer(client, { actions });
+```
+
+**Bad API PR** (only describes without showing):
+
+> This PR adds an action system that generates CLI commands and HTTP routes from action definitions.
+
+The first version lets reviewers understand the API at a glance. The second forces them to dig through the code to understand the call sites.
+
+### Before/After Code Snippets for Refactors
+
+Code examples aren't just for API changes. For internal refactors that change how code is structured without changing the public API, before/after code snippets show reviewers the improvement concretely:
+
+```typescript
+// BEFORE: direct YKeyValueLww usage with manual scanning
+const ykv = new YKeyValueLww<unknown>(yarray);
+
+function reconstructRow(rowId) {           // O(n) - scan every cell
+  for (const [key, entry] of ykv.map) {
+    if (key.startsWith(prefix)) { ... }
+  }
+}
+
+// AFTER: composed storage layers
+const cellStore = createCellStore<unknown>(ydoc, TableKey(tableId));
+const rowStore = createRowStore(cellStore);
+
+rowStore.has(id)           // O(1)
+rowStore.get(id)           // O(m) where m = fields per row
+rowStore.count()           // O(1)
+```
+
+Use before/after snippets when:
+
+- Internal implementation changes significantly even though external API is unchanged
+- Performance characteristics change and the code shows why
+- Complexity is being moved/decomposed (show what was inlined vs what's now delegated)
+
+### Visual Communication with ASCII Art
+
+Use ASCII diagrams liberally to communicate complex ideas. They're more scannable than prose and show relationships at a glance.
+
+#### Journey/Evolution Diagrams
+
+For PRs that iterate on previous work, show the evolution:
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│  PR #1217 (Jan 7)                                                       │
+│  "Add YKeyValue for 1935x storage improvement"                          │
+│                                                                         │
+│       Y.Map (524,985 bytes) ──→ YKeyValue (271 bytes)                   │
+│                                                                         │
+└───────────────────────────────────┬─────────────────────────────────────┘
+                                    │
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│  PR #1226 (Jan 8)                                                       │
+│  "Remove YKeyValue, use native Y.Map + epoch compaction"                │
+│                                                                         │
+│  Reasoning: "Unpredictable LWW behavior"  ← ⚠️ (misleading!)            │
+│                                                                         │
+└───────────────────────────────────┬─────────────────────────────────────┘
+                                    │
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│  This PR                                                                │
+│  "Restore YKeyValue with LWW timestamps"                                │
+│                                                                         │
+│  Why: Timestamp-based resolution gives intuitive "latest wins"          │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+#### Layered Architecture Diagrams
+
+Show how components stack:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  defineWorkspace() + workspace.create()                     │  ← High-level
+│    Creates Y.Doc internally, binds tables/kv/capabilities   │
+├─────────────────────────────────────────────────────────────┤
+│  createTables(ydoc, {...}) / createKv(ydoc, {...})          │  ← Mid-level
+│    Binds to existing Y.Doc                                  │
+├─────────────────────────────────────────────────────────────┤
+│  defineTable() / defineKv()                                 │  ← Low-level
+│    Pure schema definitions                                  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+#### Comparison Tables
+
+For showing trade-offs between approaches:
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│  Use Case                         │  Recommendation            │
+├───────────────────────────────────┼────────────────────────────┤
+│  Real-time collab, simple cases   │  YKeyValue (positional)    │
+│  Offline-first, multi-device      │  YKeyValueLww (timestamp)  │
+│  Clock sync unreliable            │  YKeyValue (no clock dep)  │
+└────────────────────────────────────────────────────────────────┘
+```
+
+#### Flow Diagrams
+
+For showing data/control flow:
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│                     Conflict Resolution                        │
+├────────────────────────────────────────────────────────────────┤
+│                                                                │
+│  Client A (2:00pm)  ──┐                                        │
+│                       │──→  Sync  ──→  Winner?                 │
+│  Client B (3:00pm)  ──┘                                        │
+│                                    │                           │
+│                   ┌────────────────┴────────────────┐          │
+│                   ▼                                 ▼          │
+│             YKeyValue                         YKeyValueLww     │
+│          (clientID wins)                   (timestamp wins)    │
+│           ~50% correct                       100% correct      │
+│                                                                │
+└────────────────────────────────────────────────────────────────┘
+```
+
+#### Composition Tree Diagrams
+
+For refactors that change how modules compose, use lightweight indented tree notation instead of heavy box-drawing. This shows the dependency/composition hierarchy at a glance:
+
+**Before** — one module doing everything:
+
+```
+TableHelper (schema + CRUD + row reconstruction + observers)
+  └── YKeyValueLww  ←  Map<"rowId:colId", entry>
+        ├── reconstructRow()   O(n) scan all keys for prefix
+        ├── collectRows()      O(n) group all cells by rowId
+        └── deleteRowCells()   O(n) filter + delete
+```
+
+**After** — each layer has a single responsibility:
+
+```
+TableHelper (schema validation, typed CRUD, branded Id types)
+  └── RowStore (in-memory row index → O(1) has/count, O(m) get/delete)
+      └── CellStore (cell semantics: key parsing, typed change events)
+          └── YKeyValueLww (generic LWW conflict resolution primitive)
+```
+
+Key properties of composition trees:
+
+- Use `└──` for single children, `├──` when siblings exist
+- Annotate each node with its responsibility in parentheses
+- Show performance characteristics when the refactor changes them
+- Before/after pair makes the improvement immediately visible
+
+#### File Relocation Trees
+
+When a refactor physically moves files and that relocation IS the architectural statement, show the move pattern as a tree. This is not "listing files changed" (which the skill forbids) — it's showing the structural reorganization:
+
+```
+packages/epicenter/src/
+├── shared/
+│   ├── y-cell-store.ts      →  dynamic/tables/y-cell-store.ts
+│   └── y-row-store.ts       →  dynamic/tables/y-row-store.ts
+└── dynamic/tables/
+    └── table-helper.ts         (refactored to compose over the above)
+```
+
+Use file relocation trees when:
+
+- Files moved between directories as part of a module boundary change
+- The new location communicates architectural intent (e.g., "these belong to the tables subsystem, not shared")
+- There are 2-6 files moved; more than that, describe the pattern instead
+
+Do NOT use when:
+
+- Files were renamed but stayed in the same directory
+- The move is incidental to the real change
+
+#### When to Use Diagrams
+
+- **Journey diagrams**: PR iterates on previous work or fixes a past decision
+- **Layer diagrams**: PR introduces or changes architecture with distinct levels
+- **Composition trees**: PR refactors how modules compose or delegate to each other
+- **File relocation trees**: PR moves files between directories as an architectural statement
+- **Comparison tables**: PR introduces alternatives or explains trade-offs
+- **Flow diagrams**: PR changes how data or control moves between components
+
+ASCII art characters to use: `┌ ┐ └ ┘ ─ │ ├ ┤ ┬ ┴ ┼ ▼ ▲ ◀ ▶ ──→ ←── ⚠️ ✅ ❌`
+
+#### Interleaving Prose and Visuals
+
+Never let prose run for more than a short paragraph without a visual break. The rhythm should be: context → visual → explanation → visual → ...
+
+Each visual (code snippet, ASCII diagram, before/after block) should be preceded by 1-3 sentences of context and optionally followed by a sentence explaining the subtle detail. If you're writing more than 4-5 sentences of prose in a row, you're missing an opportunity for a diagram or code block.
+
+**Good rhythm** — prose and visuals alternate naturally:
+
+```
+[1-2 sentences: what the problem is and why it matters]
+
+\`\`\`typescript
+// code example showing the new API
+workspace.extensions.sync.reconnect(directAuth('https://cloud.example.com'));
+\`\`\`
+
+\`\`\`
+┌────────────────────────────┐
+│  Flow diagram showing how  │──► what happens step by step
+│  the pieces connect        │
+└────────────────────────────┘
+\`\`\`
+
+[1-2 sentences: explain a subtle implementation detail]
+
+\`\`\`typescript
+// before/after showing the fix
+\`\`\`
+
+[1 sentence: why the before was broken]
+
+\`\`\`
+┌──────────────────────────────────┐
+│  Architecture diagram showing    │
+│  which parts are affected        │
+└──────────────────────────────────┘
+\`\`\`
+```
+
+**Bad rhythm** — wall of text with visuals tacked on at the end:
+
+```
+[Paragraph explaining the problem]
+[Paragraph explaining the solution]
+[Paragraph explaining the implementation detail]
+[Paragraph explaining another detail]
+
+\`\`\`
+[single diagram at the bottom]
+\`\`\`
+```
+
+The reader's eye should bounce between prose and visuals. Prose provides the "why," visuals provide the "what" and "how." Neither should dominate for long stretches.
+
+### Other Guidelines
+
+- NEVER include Claude Code or opencode watermarks or attribution in PR titles/descriptions
+- PR title should follow same conventional commit format as commits
+- Focus on the "why" and "what" of changes, not the "how it was created"
+- Include any breaking changes prominently
+- Link to relevant issues
+
+### Scanning GitHub Issues Before Writing a PR Description
+
+Before drafting a PR description, run a cursory search of open GitHub issues to identify any that the PR's changes may fix, partially address, or lay groundwork for:
+
+```bash
+# List open issues (scan titles for keywords matching the PR's scope)
+gh issue list --state open --limit 100 --json number,title,labels
+
+# Read a specific issue to check if the PR addresses it
+gh issue view <NUMBER> --json title,body,labels,comments
+```
+
+**What to look for:**
+- Issues whose root cause matches code you changed (e.g., error handling, provider bugs, API connection issues)
+- Feature requests where your changes are a prerequisite (mention as "lays groundwork for")
+- Bug reports where your changes improve error messages or diagnostics without fully fixing the bug
+
+**How to reference in the PR description:**
+- `Closes #123` — only if the PR fully resolves the issue
+- `Partially addresses #123` — if the PR improves the situation but doesn't fully fix it
+- `Lays groundwork for #123` — if the PR creates infrastructure that a future PR will use to fix the issue
+
+**Be honest:** Don't claim a fix unless the changes directly address the root cause. Improved error messages or internal refactors that happen to touch related code do not count as fixes.
+
+### Verifying GitHub Usernames
+
+**CRITICAL**: When mentioning GitHub users with `@username` in PR descriptions, issue comments, or any GitHub content, NEVER guess or assume usernames. Always verify programmatically using the GitHub CLI:
+
+```bash
+# Get the author of a PR
+gh pr view <PR_NUMBER> --json author
+
+# Get the author of an issue
+gh issue view <ISSUE_NUMBER> --json author
+```
+
+This prevents embarrassing mistakes where you credit the wrong person. Always run the verification command before writing the @mention.
+
+### Merge Strategy
+
+When merging PRs, use regular merge commits (NOT squash):
+
+```bash
+gh pr merge --merge  # Correct: preserves commit history
+# NOT: gh pr merge --squash
+# NOT: gh pr merge --rebase
+
+# Use --admin flag if needed to bypass branch protections
+gh pr merge --merge --admin
+```
+
+Preserve individual commits; they tell the story of how the work evolved.
+
+### Pull Request Body Format
+
+#### Simple PRs (single-purpose changes)
+
+Use clean paragraph format:
+
+**First Paragraph**: Explain what the change does and what problem it solves.
+
+**Subsequent Paragraphs**: Explain how the implementation works.
+
+**Example**:
+
+```
+This change enables proper vertical scrolling for drawer components when content exceeds the available drawer height. Previously, drawers with long content could overflow without proper scrolling behavior, making it difficult for users to access all content and resulting in poor mobile UX.
+
+To accomplish this, I wrapped the `{@render children?.()}` in a `<div class="flex-1 overflow-y-auto">` container. The `flex-1` class ensures the content area takes up all remaining space after the fixed drag handle at the top, while `overflow-y-auto` enables vertical scrolling when the content height exceeds the available space.
+```
+
+#### Architectural PRs (API changes, structural refactors)
+
+For PRs that change APIs, storage structures, or architectural patterns, use this section order:
+
+1. **Opening sentence**: A single crisp sentence summarizing WHAT changed — what was added, removed, or redesigned. This grounds the reader before the motivation.
+
+2. **Why paragraph**: WHY this change exists. What problem does analysis reveal? What was the old design masking? End with a **one-sentence decision summary** if applicable: "We chose X over Y because Z."
+
+3. **Change bullets**: A short bullet list of the specific changes — new APIs, removed patterns, behavioral differences. Bullets complement the prose here; they don't replace it.
+
+4. **API Migration**: Before/after code examples showing the new usage. Mandatory for any API change.
+
+5. **Storage/Data Structure**: ASCII diagrams showing before/after layouts for any structural changes.
+
+6. **Technical Details**: Extension points, type definitions, configuration formats — with code examples.
+
+7. **"Why X?" sections**: Use a named `### Why X?` heading for each significant design decision that needs justification. Write as direct statements, not hedged observations.
+
+8. **Future Work**: What could be re-added later, what's intentionally deferred.
+
+9. **(Optional) Changes Summary / Test Plan**: If included, keep minimal and put at the very end. Most PRs don't need one.
+
+**Key principles**:
+
+- **Visual-first**: Each section should lead with code or ASCII diagrams; prose explains the visuals
+- Code snippets and ASCII art are the most scannable — feature them prominently
+- Rationale is prose-only (no visual needed); it explains the thinking
+- Skip the "Changes" section entirely, or make it minimal at the end
+
+**When to use Architectural format**:
+
+- Public API shape changes (exports, signatures, config formats)
+- Persistent data format changes (storage layout, migrations)
+- Cross-package contract changes
+- New subsystem or major refactor
+
+**When to use Simple format**:
+
+- Localized fix/feature with no consumer migration
+- Behavior-preserving internal refactor
+
+#### Voice and Tone
+
+- **Conversational but precise**: Write like explaining to a colleague
+- **Direct and honest**: "This has been painful" rather than "This presented challenges"
+- **Show your thinking**: "We considered X, but Y made more sense because..."
+- **Use "we" for team decisions, "I" for personal observations**
+
+#### Example PR Description:
+
+````
+This fixes the long-standing issue with nested reactivity in state management.
+
+First, some context: users have consistently found it cumbersome to create deeply reactive state. The current approach requires manual get/set properties, which doesn't feel sufficiently Svelte-like. Meanwhile, we want to move away from object mutation for future performance optimizations, but `obj = { ...obj, x: obj.x + 1 }` is ugly and creates overhead.
+
+This PR introduces proxy-based reactivity that lets you write idiomatic JavaScript:
+
+```javascript
+let todos = $state([]);
+todos.push({ done: false, text: 'Learn Svelte' }); // just works
+```
+
+Under the hood, we're using Proxies to lazily create signals as necessary. This gives us the ergonomics of mutation with the performance benefits of immutability.
+
+Still TODO:
+- Performance optimizations for large arrays
+- Documentation updates
+- Migration guide for existing codebases
+
+This doubles down on Svelte's philosophy of writing less, more intuitive code while setting us up for the fine-grained reactivity improvements planned for v6.
+````
+
+#### What to Avoid
+
+- **Listing files changed**: Never enumerate which files were modified. GitHub's "Files changed" tab already shows this; the PR description should explain WHY, not WHAT files
+- **"Changes" sections at the top**: If you need a changes summary, put it at the very end and keep it minimal. Most PRs don't need one.
+- **Test plans**: Skip unless specifically requested. Tests should be in the code, not described in prose.
+- **Section headers like "## Summary" or "## Changes Made"**
+- Bullet points or structured lists as a substitute for explanatory prose (bullets for the change list are fine)
+- Marketing language or excessive formatting
+- Corporate language: "This PR enhances our solution by leveraging..."
+- Marketing speak: "game-changing", "revolutionary", "seamless"
+- Clichés like "first principles"
+- Dramatic hyperbole: "feels like an eternity", "pain point", "excruciating" — stick to facts ("saves 150ms") not drama
+- Over-explaining simple changes
+- Apologetic tone for reasonable decisions
+
+## What NOT to Include:
+
+- `Generated with [Claude Code](https://claude.ai/code)`
+- `Co-Authored-By: Claude <noreply@anthropic.com>`
+- Any references to AI assistance
+- `Generated with [opencode](https://opencode.ai)`
+- `Co-Authored-By: opencode <noreply@opencode.ai>`
+- Tool attribution or watermarks

--- a/.claude/skills/honesty/SKILL.md
+++ b/.claude/skills/honesty/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: honesty
+description: Behavioral guideline for providing brutally honest feedback. Use always - this skill defines core interaction expectations for code review and technical discussions.
+---
+
+# Honesty
+
+Be brutally honest, don't be a yes man.
+If I am wrong, point it out bluntly.
+I need honest feedback on my code.

--- a/.claude/skills/incremental-commits/SKILL.md
+++ b/.claude/skills/incremental-commits/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: incremental-commits
+description: Break multi-file changes into atomic commits ordered by dependency. Use for refactors, breaking API changes, or features touching 3+ files.
+---
+
+# Incremental Commits
+
+When a feature touches multiple files, implement in **waves**. Each wave is one logical concern, one commit. This creates a clean git history that tells a story.
+
+## The Pattern
+
+```
+Wave 1: Foundation (types, interfaces)
+  ↓
+Wave 2: Factories/Builders (functions that create instances)
+  ↓
+Wave 3: Contracts/APIs (public interfaces that use types)
+  ↓
+Wave 4: Infrastructure (utilities, converters, dependencies)
+  ↓
+Wave 5: Consumers (apps, UI, integrations)
+```
+
+Not every change needs all waves. A simple bugfix might be one wave. A cross-cutting refactor might need five.
+
+## Wave Characteristics
+
+Each wave must be:
+
+| Property      | Description                                    |
+| ------------- | ---------------------------------------------- |
+| **Atomic**    | One logical concern per wave                   |
+| **Buildable** | Code compiles after this wave (run type-check) |
+| **Focused**   | Changes relate to ONE layer/concern            |
+| **Complete**  | No half-done work within a wave                |
+
+## Real Example: Schema Refactor
+
+This feature moved metadata from workspace to tables. Five waves:
+
+### Wave 1: Types
+
+```
+feat(schema): add IconDefinition, CoverDefinition, and FieldMetadata types
+
+- Add IconDefinition discriminated union (emoji | external)
+- Add CoverDefinition discriminated union (external)
+- Add FieldMetadata with optional name/description to all field types
+- Update TableDefinition to use icon/cover instead of emoji/order
+```
+
+Files: `types.ts` only. Foundation for everything else.
+
+### Wave 2: Factories
+
+```
+feat(schema): add optional name/description to field factory functions
+
+All factory functions (id, text, richtext, integer, real, boolean, date,
+select, tags, json) now accept optional name and description parameters.
+```
+
+Files: `factories.ts` only. Uses types from Wave 1.
+
+### Wave 3: Contracts
+
+```
+feat(schema): remove emoji and description from WorkspaceSchema
+
+Workspace is now just a container with guid, id, name, tables, and kv.
+Visual metadata (icon, cover, description) now lives on TableDefinition.
+```
+
+Files: `contract.ts` only. API change using new types.
+
+### Wave 4: Infrastructure
+
+```
+feat(schema): use slugify for human-readable SQL column names
+
+- Add @sindresorhus/slugify dependency
+- Add toSqlIdentifier() helper using slugify with '_' separator
+- SQLite columns now use field.name (or derived from key) instead of key
+```
+
+Files: `to-drizzle.ts`, `package.json`. Utility that uses field metadata.
+
+### Wave 5: Consumers
+
+```
+feat(schema): update epicenter app to use TablesWithMetadata
+
+- WorkspaceSchema now accepts TablesSchema | TablesWithMetadata
+- Export new types from package index
+- Update app to create proper TableDefinition with metadata
+```
+
+Files: App files that consume the new types.
+
+## The Workflow
+
+1. **Plan waves before coding**
+   - List files that need changes
+   - Group by layer/concern
+   - Order by dependency (foundations first)
+
+2. **Implement one wave**
+   - Make changes for that wave only
+   - Resist temptation to "fix one more thing"
+
+3. **Verify the wave**
+   - Run type-check: `bun run tsc --noEmit`
+   - Ensure no errors introduced
+
+4. **Commit the wave**
+   - Use conventional commit format
+   - Message describes what this wave accomplishes
+   - Body can list specific changes
+
+5. **Repeat for next wave**
+
+## When to Use Waves
+
+| Scenario                 | Waves? | Why                        |
+| ------------------------ | ------ | -------------------------- |
+| Single file bugfix       | No     | One change, one commit     |
+| Add new type + factory   | Maybe  | Could be 1-2 waves         |
+| Refactor across 5+ files | Yes    | Need logical grouping      |
+| Breaking API change      | Yes    | Types → API → Consumers    |
+| Add dependency + use it  | Yes    | Infra wave then usage wave |
+
+## Anti-Patterns
+
+### Giant Commit
+
+```
+refactor: update schema system
+
+- Add new types
+- Update factories
+- Change contracts
+- Add slugify
+- Update app
+```
+
+Problem: One monolithic commit. Can't bisect, can't revert partially, no story.
+
+### Micro Commits
+
+```
+feat: add IconDefinition type
+feat: add CoverDefinition type
+feat: add FieldMetadata type
+feat: update IdFieldSchema
+feat: update TextFieldSchema
+...
+```
+
+Problem: Too granular. 20 commits for one logical change. Noise.
+
+### Wrong Order
+
+```
+Wave 1: Update app to use new types  ❌
+Wave 2: Add the types                 ❌
+```
+
+Problem: Wave 1 won't compile. Bottom-up, not top-down.
+
+## Dependency Order Heuristic
+
+When deciding wave order, ask: "What does this file import?"
+
+```
+types.ts         → imports nothing (foundation)
+factories.ts     → imports types.ts
+contract.ts      → imports types.ts
+converters.ts    → imports types.ts, may add deps
+app/             → imports everything above
+```
+
+Files that import nothing come first. Files that import everything come last.
+
+## Branch Strategy
+
+For multi-wave work:
+
+```bash
+# Create feature branch
+git checkout -b feat/my-feature
+
+# Wave 1
+# ... make changes ...
+git add <files> && git commit -m "feat(scope): wave 1 description"
+
+# Wave 2
+# ... make changes ...
+git add <files> && git commit -m "feat(scope): wave 2 description"
+
+# ... continue waves ...
+
+# When done, all waves are individual commits on the branch
+# PR shows clean history of how the feature evolved
+```
+
+## Quick Reference
+
+Before starting:
+
+- [ ] List all files that need changes
+- [ ] Group by layer (types, factories, contracts, infra, consumers)
+- [ ] Order by dependency
+
+For each wave:
+
+- [ ] Change only files in this wave
+- [ ] Run type-check
+- [ ] Commit with descriptive message
+- [ ] Move to next wave
+
+After all waves:
+
+- [ ] Final type-check
+- [ ] Run tests if applicable
+- [ ] Create PR with clean commit history

--- a/.claude/skills/method-shorthand-jsdoc/SKILL.md
+++ b/.claude/skills/method-shorthand-jsdoc/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: method-shorthand-jsdoc
+description: Move helper functions into return objects using method shorthand for proper JSDoc preservation. Use when factory functions have internal helpers that should expose documentation to consumers, or when hovering over returned methods shows no JSDoc.
+metadata:
+  author: epicenter
+  version: '1.0'
+---
+
+# Method Shorthand for JSDoc Preservation
+
+When factory functions have helper functions that are only used by returned methods, move them INTO the return object using method shorthand. This ensures JSDoc comments are properly passed through to consumers.
+
+## The Problem
+
+You write a factory function with a well-documented helper:
+
+```typescript
+function createHeadDoc(options: { workspaceId: string }) {
+	const { workspaceId } = options;
+
+	/**
+	 * Get the current epoch number.
+	 *
+	 * Computes the maximum of all client-proposed epochs.
+	 * This ensures concurrent bumps converge to the same version.
+	 *
+	 * @returns The current epoch (0 if no bumps have occurred)
+	 */
+	function getEpoch(): number {
+		let max = 0;
+		for (const value of epochsMap.values()) {
+			max = Math.max(max, value);
+		}
+		return max;
+	}
+
+	return {
+		workspaceId,
+		getEpoch, // JSDoc is NOT visible when hovering on returned object!
+
+		bumpEpoch(): number {
+			const next = getEpoch() + 1; // Calling internal helper
+			return next;
+		},
+	};
+}
+```
+
+When you hover over `head.getEpoch()` in your IDE, you see... nothing. The JSDoc is lost.
+
+## The Solution
+
+Move the helper INTO the return object using method shorthand:
+
+```typescript
+function createHeadDoc(options: { workspaceId: string }) {
+	const { workspaceId } = options;
+
+	return {
+		workspaceId,
+
+		/**
+		 * Get the current epoch number.
+		 *
+		 * Computes the maximum of all client-proposed epochs.
+		 * This ensures concurrent bumps converge to the same version.
+		 *
+		 * @returns The current epoch (0 if no bumps have occurred)
+		 */
+		getEpoch(): number {
+			let max = 0;
+			for (const value of epochsMap.values()) {
+				max = Math.max(max, value);
+			}
+			return max;
+		},
+
+		bumpEpoch(): number {
+			const next = this.getEpoch() + 1; // Use this.methodName()
+			return next;
+		},
+	};
+}
+```
+
+Now hovering over `head.getEpoch()` shows the full JSDoc.
+
+## Why This Works
+
+1. **JSDoc attaches to the method definition site** - when methods are inline in the return object, the JSDoc is directly on the property TypeScript sees
+2. **Method shorthand uses `function` semantics** - `this` is bound to the object, so `this.getEpoch()` works
+3. **No separate helper needed** - if it's only used by sibling methods, it belongs in the same object
+
+## The Pattern
+
+```typescript
+// BAD: Helper defined separately, JSDoc lost on return
+function createService(client) {
+  /** Fetches user data with caching. */
+  function fetchUser(id: string) { ... }
+
+  return {
+    fetchUser,  // JSDoc not visible to consumers!
+    getProfile(id: string) {
+      return fetchUser(id);  // Works, but consumers can't see docs
+    },
+  };
+}
+
+// GOOD: Method shorthand, JSDoc preserved
+function createService(client) {
+  return {
+    /** Fetches user data with caching. */
+    fetchUser(id: string) { ... },
+
+    getProfile(id: string) {
+      return this.fetchUser(id);  // Use this.method()
+    },
+  };
+}
+```
+
+## When to Apply
+
+Use this pattern when:
+
+- Helper functions are ONLY used by methods in the return object
+- You want JSDoc visible when consumers hover over the method
+- The helper doesn't need to be called before the return statement
+
+Keep helpers separate when:
+
+- They're called during initialization (before return)
+- They're used by multiple factories (extract to shared module)
+- They're truly internal and shouldn't be exposed
+
+## Arrow Functions Don't Work
+
+Arrow functions don't have their own `this`:
+
+```typescript
+// BAD: Arrow function, this is undefined
+return {
+  getEpoch: () => { ... },
+  bumpEpoch: () => {
+    this.getEpoch();  // ERROR: this is undefined!
+  },
+};
+
+// GOOD: Method shorthand has correct this binding
+return {
+  getEpoch() { ... },
+  bumpEpoch() {
+    this.getEpoch();  // Works!
+  },
+};
+```
+
+## Real Example
+
+From `packages/epicenter/src/core/docs/head-doc.ts`:
+
+```typescript
+export function createHeadDoc(options: { workspaceId: string; ydoc?: Y.Doc }) {
+	const { workspaceId } = options;
+	const ydoc = options.ydoc ?? new Y.Doc({ guid: workspaceId });
+	const epochsMap = ydoc.getMap<number>('epochs');
+
+	return {
+		ydoc,
+		workspaceId,
+
+		/**
+		 * Get the current epoch number.
+		 *
+		 * Computes the maximum of all client-proposed epochs.
+		 * This ensures concurrent bumps converge to the same version
+		 * without skipping epoch numbers.
+		 *
+		 * @returns The current epoch (0 if no bumps have occurred)
+		 */
+		getEpoch(): number {
+			let max = 0;
+			for (const value of epochsMap.values()) {
+				max = Math.max(max, value);
+			}
+			return max;
+		},
+
+		/**
+		 * Bump the epoch to the next version.
+		 *
+		 * @returns The new epoch number after bumping
+		 */
+		bumpEpoch(): number {
+			const next = this.getEpoch() + 1;
+			epochsMap.set(ydoc.clientID.toString(), next);
+			return next;
+		},
+
+		// ... other methods using this.getEpoch()
+	};
+}
+```
+
+## Summary
+
+| Approach                    | JSDoc Visible? | `this` Works? |
+| --------------------------- | -------------- | ------------- |
+| Separate helper + reference | No             | N/A           |
+| Arrow function in return    | Yes            | No            |
+| Method shorthand in return  | Yes            | Yes           |
+
+Method shorthand is the only approach that preserves JSDoc AND allows methods to call each other via `this`.
+
+## Where This Fits in the Factory Function Anatomy
+
+Factory functions follow a four-zone internal shape: immutable state → mutable state → private helpers → return object. Method shorthand lives in the return object (zone 4)—the public API.
+
+The `this.method()` vs direct-call decision depends on which zone the function lives in:
+
+| Situation | Where it lives | How to call it |
+|---|---|---|
+| Only used by sibling methods in the return object | Zone 4 (return object, method shorthand) | `this.method()` |
+| Used by return-object methods AND pre-return init logic | Zone 3 (private helper, standalone function) | Direct call: `helperFn()` |
+| Used during initialization only, not exposed | Zone 3 (private helper) | Direct call: `helperFn()` |
+
+When a helper needs to be in zone 3, its JSDoc won't be visible to consumers—but that's correct, because it's a private implementation detail. Only zone 4 methods need consumer-facing JSDoc.
+
+See [Closures Are Better Privacy Than Keywords](../../docs/articles/closures-are-better-privacy-than-keywords.md) for the full factory function anatomy.
+
+## References
+
+- [docs/articles/method-shorthand-jsdoc-preservation.md](../../docs/articles/method-shorthand-jsdoc-preservation.md) - Same content as article
+- [docs/articles/closures-are-better-privacy-than-keywords.md](../../docs/articles/closures-are-better-privacy-than-keywords.md) - Factory function anatomy and zone system

--- a/.claude/skills/progress-summary/SKILL.md
+++ b/.claude/skills/progress-summary/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: progress-summary
+description: This skill should be used when the user asks questions like "can you summarize", "what happened", "what did we do", "what's the situation", "where are we at", "explain what's going on", "give me an overview", "what's been done", "tell me about this", "walk me through what happened", or any question asking to understand the current state of work or changes. Provides conversational, PR-style summaries with visual diagrams.
+---
+
+# Progress Summary
+
+Generate conversational summaries of work in progress, using the same style as well-crafted PR descriptions.
+
+## Core Principles
+
+### Motivation First
+
+Every summary starts with WHY. Not what files changed, not how it works—WHY this work matters.
+
+**Good opening**:
+> We've been tackling the session timeout issue that was logging users out mid-upload. The root cause was the session refresh only triggering on navigation, not during background activity.
+
+**Bad opening**:
+> We added a keepalive call to the upload handler and updated the session refresh logic.
+
+The reader should understand the PROBLEM before seeing the SOLUTION.
+
+### Show Your Thinking
+
+Summaries should reveal the decision-making process:
+
+- "We considered X, but Y made more sense because..."
+- "Initially tried A, which revealed B, leading us to C"
+- "The tricky part was figuring out where to hook into the existing flow"
+
+### Conversational but Precise
+
+Write like explaining to a colleague over coffee. Direct and honest.
+
+- "This has been painful" rather than "This presented challenges"
+- "We hit a wall with" rather than "We encountered difficulties"
+- Use "we" for collaborative work, "I" for personal observations
+
+## Summary Types
+
+### Quick Status (verbal check-in)
+
+For "what are you working on" or brief updates:
+
+```
+Working on the auth timeout issue. Found the root cause: session refresh
+only fires on navigation, not background activity. Currently implementing
+a keepalive mechanism in the upload handler.
+```
+
+2-4 sentences. Problem, finding, current action.
+
+### Session Recap (end of work session)
+
+For "summarize what we did" or wrapping up:
+
+**Structure**:
+1. What problem we tackled
+2. Key decisions made (and why)
+3. What's working now
+4. What's left to do
+
+**Example**:
+```
+We tackled the nested reactivity problem in state management. Users found
+it cumbersome to create deeply reactive state with manual get/set properties.
+
+After exploring several approaches, we landed on proxy-based reactivity
+because it lets you write idiomatic JavaScript while we get the performance
+benefits of immutability under the hood.
+
+The core implementation is working. Still need to optimize for large arrays
+and update the migration guide.
+```
+
+### Architecture Overview (explaining a complex change)
+
+For "explain what's happening here" on larger work:
+
+Use ASCII diagrams liberally. They're more scannable than prose.
+
+**Journey/Evolution Diagrams** (when work iterates on previous attempts):
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  First attempt: Direct Y.Map                                     │
+│  Problem: 524,985 bytes storage overhead                         │
+└───────────────────────────────────────┬─────────────────────────┘
+                                        │
+                                        ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  Second attempt: YKeyValue wrapper                               │
+│  Result: 271 bytes (1935x improvement!)                          │
+│  Problem: Unpredictable conflict resolution                      │
+└───────────────────────────────────────┬─────────────────────────┘
+                                        │
+                                        ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  Current: YKeyValue with LWW timestamps                          │
+│  Keeps the storage wins, adds predictable "latest wins"          │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Layer Diagrams** (for architectural changes):
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  defineWorkspace() + workspace.create()                          │  ← High-level
+│    Creates Y.Doc internally, binds tables/kv/capabilities        │
+├─────────────────────────────────────────────────────────────────┤
+│  createTables(ydoc, {...}) / createKv(ydoc, {...})               │  ← Mid-level
+│    Binds to existing Y.Doc                                       │
+├─────────────────────────────────────────────────────────────────┤
+│  defineTable() / defineKv()                                      │  ← Low-level
+│    Pure schema definitions                                       │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Flow Diagrams** (for data/control flow):
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│  Client A (2:00pm)  ──┐                                        │
+│                       │──→  Sync  ──→  Winner: Client B        │
+│  Client B (3:00pm)  ──┘                                        │
+│                                                                │
+│  With timestamps: Latest always wins                           │
+│  Without: Whoever syncs first wins (unpredictable)             │
+└────────────────────────────────────────────────────────────────┘
+```
+
+**Comparison Tables** (for trade-offs):
+
+```
+┌────────────────────────────────────┬────────────────────────────┐
+│  Use Case                          │  Recommendation            │
+├────────────────────────────────────┼────────────────────────────┤
+│  Real-time collab, simple cases    │  YKeyValue (positional)    │
+│  Offline-first, multi-device       │  YKeyValueLww (timestamp)  │
+│  Clock sync unreliable             │  YKeyValue (no clock dep)  │
+└────────────────────────────────────┴────────────────────────────┘
+```
+
+## When to Use Diagrams
+
+- **Journey diagrams**: Work iterates on previous attempts or fixes past decisions
+- **Layer diagrams**: Architectural changes with distinct levels
+- **Comparison tables**: Trade-offs between approaches
+- **Flow diagrams**: How data or control moves between components
+
+## What to Avoid
+
+- **Listing files changed**: "Updated auth.ts, session.ts, and upload.ts" — just explain what and why
+- **Corporate speak**: "This enhancement leverages our existing infrastructure"
+- **Marketing language**: "game-changing", "revolutionary", "seamless"
+- **Dramatic hyperbole**: "excruciating pain point" — stick to facts
+- **Bullet point everything**: Use flowing paragraphs when possible
+- **Over-explaining simple changes**: Match the explanation depth to the complexity
+
+## Gathering Context for Summaries
+
+To generate a summary, gather relevant context:
+
+```bash
+# Current branch state
+git status
+git log --oneline -10
+
+# What changed from main
+git diff main...HEAD --stat
+git log main..HEAD --oneline
+
+# Recent activity
+git log --oneline --since="1 hour ago"
+```
+
+For Conductor workspaces, use `GetWorkspaceDiff` to see the full diff.
+
+Read key files that were modified to understand the substance of changes, not just the diff stats.
+
+## ASCII Art Characters
+
+For clean diagrams: `┌ ┐ └ ┘ ─ │ ├ ┤ ┬ ┴ ┼ ▼ ▲ ◀ ▶ ──→ ←──`
+
+Keep box edges aligned. Use consistent spacing inside boxes.

--- a/.claude/skills/query-layer/SKILL.md
+++ b/.claude/skills/query-layer/SKILL.md
@@ -1,0 +1,468 @@
+---
+name: query-layer
+description: Query layer patterns for consuming services with TanStack Query, error transformation, and runtime dependency injection. Use when implementing queries/mutations, transforming service errors for UI, or adding reactive data management.
+metadata:
+  author: epicenter
+  version: '1.1'
+---
+
+# Query Layer Patterns
+
+The query layer is the reactive bridge between UI components and the service layer. It wraps pure service functions with caching, reactivity, and state management using TanStack Query and WellCrafted factories.
+
+## When to Apply This Skill
+
+Use this pattern when you need to:
+
+- Create queries or mutations that consume services
+- Transform service-layer errors into user-facing error types
+- Implement runtime service selection based on user settings
+- Add optimistic cache updates for instant UI feedback
+- Understand the dual interface pattern (reactive vs imperative)
+
+## Core Architecture
+
+```
+┌─────────────┐     ┌─────────────┐     ┌──────────────┐
+│     UI      │ --> │  RPC/Query  │ --> │   Services   │
+│ Components  │     │    Layer    │     │    (Pure)    │
+└─────────────┘     └─────────────┘     └──────────────┘
+      ↑                    │
+      └────────────────────┘
+         Reactive Updates
+```
+
+**Query Layer Responsibilities:**
+
+- Call services with injected settings/configuration
+- Transform service errors to user-facing error types for display
+- Manage TanStack Query cache for optimistic updates
+- Provide dual interfaces: reactive (`.options`) and imperative (`.execute()`)
+
+## Error Transformation Pattern
+
+**Critical**: Service errors should be transformed to user-facing error types at the query layer boundary.
+
+### Three-Layer Error Flow
+
+```
+Service Layer         →  Query Layer           →  UI Layer
+TaggedError<'Name'>   →  UserFacingError       →  Toast notification
+(domain-specific)        (display-ready)          (display)
+```
+
+### Standard Error Transformation
+
+```typescript
+import { Err, Ok } from 'wellcrafted/result';
+
+// In query layer - transform service error to user-facing error
+const { data, error } = await services.recorder.startRecording(params);
+
+if (error) {
+	return Err({
+		title: '❌ Failed to start recording',
+		description: error.message,
+		action: { type: 'more-details', error },
+	});
+}
+
+return Ok(data);
+```
+
+### Real-World Examples
+
+```typescript
+// Simple error transformation
+enumerateDevices: defineQuery({
+  queryKey: recorderKeys.devices,
+  queryFn: async () => {
+    const { data, error } = await recorderService().enumerateDevices();
+    if (error) {
+      return Err({
+        title: '❌ Failed to enumerate devices',
+        description: error.message,
+        action: { type: 'more-details', error },
+      });
+    }
+    return Ok(data);
+  },
+}),
+
+// Custom description when service message isn't enough
+stopRecording: defineMutation({
+  mutationFn: async ({ toastId }) => {
+    const { data: blob, error } = await recorderService().stopRecording({ sendStatus });
+
+    if (error) {
+      return Err({
+        title: '❌ Failed to stop recording',
+        description: error.message,
+        action: { type: 'more-details', error },
+      });
+    }
+
+    if (!recordingId) {
+      return Err({
+        title: '❌ Missing recording ID',
+        description: 'An internal error occurred: recording ID was not set.',
+      });
+    }
+
+    return Ok({ blob, recordingId });
+  },
+}),
+```
+
+### Anti-Pattern: Double Wrapping
+
+Never wrap an already-wrapped error:
+
+```typescript
+// ❌ BAD: Double wrapping
+if (error) {
+  const userError = Err({ title: 'Failed', description: error.message });
+  notify.error.execute({ id: nanoid(), ...userError.error });  // Don't spread!
+  return userError;
+}
+
+// ✅ GOOD: Transform once, use directly
+if (error) {
+  return Err({
+    title: '❌ Failed to start recording',
+    description: error.message,
+  });
+}
+// In onError hook, error is already the user-facing type
+onError: (error) => notify.error.execute(error),
+```
+
+## Runtime Dependency Injection
+
+The query layer dynamically selects service implementations based on user settings.
+
+### Service Selection Pattern
+
+```typescript
+// From transcription.ts - Switch between providers
+async function transcribeBlob(blob: Blob): Promise<Result<string, UserError>> {
+	const selectedService =
+		settings.value['transcription.selectedTranscriptionService'];
+
+	switch (selectedService) {
+		case 'OpenAI':
+			return await services.transcriptions.openai.transcribe(blob, {
+				apiKey: settings.value['apiKeys.openai'],
+				modelName: settings.value['transcription.openai.model'],
+				outputLanguage: settings.value['transcription.outputLanguage'],
+				prompt: settings.value['transcription.prompt'],
+				temperature: settings.value['transcription.temperature'],
+			});
+		case 'Groq':
+			return await services.transcriptions.groq.transcribe(blob, {
+				apiKey: settings.value['apiKeys.groq'],
+				modelName: settings.value['transcription.groq.model'],
+				outputLanguage: settings.value['transcription.outputLanguage'],
+				prompt: settings.value['transcription.prompt'],
+				temperature: settings.value['transcription.temperature'],
+			});
+		// ... more cases
+		default:
+			return Err({
+				title: '⚠️ No transcription service selected',
+				description: 'Please select a transcription service in settings.',
+			});
+	}
+}
+```
+
+### Recorder Service Selection
+
+```typescript
+// Platform + settings-based selection
+export function recorderService() {
+	// In browser, always use navigator recorder
+	if (!window.__TAURI_INTERNALS__) return services.navigatorRecorder;
+
+	// On desktop, use settings
+	const recorderMap = {
+		navigator: services.navigatorRecorder,
+		ffmpeg: desktopServices.ffmpegRecorder,
+		cpal: desktopServices.cpalRecorder,
+	};
+	return recorderMap[settings.value['recording.method']];
+}
+```
+
+## Dual Interface Pattern
+
+Every query/mutation provides two ways to use it:
+
+### Reactive Interface: `.options`
+
+Use in Svelte components for automatic state management. Pass `.options` (a static object) inside an accessor function:
+
+```svelte
+<script lang="ts">
+	import { createQuery, createMutation } from '@tanstack/svelte-query';
+	import { rpc } from '$lib/query';
+
+	// Reactive query - wrap in accessor function, access .options (no parentheses)
+	const recordings = createQuery(() => rpc.db.recordings.getAll.options);
+
+	// Reactive mutation - same pattern
+	const deleteRecording = createMutation(
+		() => rpc.db.recordings.delete.options,
+	);
+</script>
+
+{#if recordings.isPending}
+	<Spinner />
+{:else if recordings.error}
+	<Error message={recordings.error.description} />
+{:else}
+	{#each recordings.data as recording}
+		<RecordingCard
+			{recording}
+			onDelete={() => deleteRecording.mutate(recording)}
+		/>
+	{/each}
+{/if}
+```
+
+### Imperative Interface: `.execute()` / `.fetch()`
+
+Use in event handlers and workflows without reactive overhead:
+
+```typescript
+// In an event handler or workflow
+async function handleBulkDelete(recordings: Recording[]) {
+	for (const recording of recordings) {
+		const { error } = await rpc.db.recordings.delete.execute(recording);
+		if (error) {
+			notify.error.execute(error);
+			return;
+		}
+	}
+	notify.success.execute({ title: 'All recordings deleted' });
+}
+
+// In a sequential workflow
+async function stopAndTranscribe(toastId: string) {
+	const { data: blobData, error: stopError } =
+		await rpc.recorder.stopRecording.execute({ toastId });
+
+	if (stopError) {
+		notify.error.execute(stopError);
+		return;
+	}
+
+	// Continue with transcription...
+}
+```
+
+### When to Use Each
+
+| Use `.options` with createQuery/createMutation | Use `.execute()`/`.fetch()` |
+| ---------------------------------------------- | --------------------------- |
+| Component data display                         | Event handlers              |
+| Loading spinners needed                        | Sequential workflows        |
+| Auto-refetch wanted                            | One-time operations         |
+| Reactive state needed                          | Outside component context   |
+| Cache synchronization                          | Performance-critical paths  |
+
+## Cache Management
+
+### Optimistic Updates Pattern
+
+Update the cache immediately, then sync with server:
+
+```typescript
+create: defineMutation({
+  mutationKey: ['db', 'recordings', 'create'] as const,
+  mutationFn: async (params: { recording: Recording; audio: Blob }) => {
+    const { error } = await services.db.recordings.create(params);
+    if (error) return Err(error);
+
+    // Optimistic cache updates - UI updates instantly
+    queryClient.setQueryData<Recording[]>(
+      dbKeys.recordings.all,
+      (oldData) => [...(oldData || []), params.recording],
+    );
+    queryClient.setQueryData<Recording>(
+      dbKeys.recordings.byId(params.recording.id),
+      params.recording,
+    );
+
+    // Invalidate to refetch fresh data in background
+    queryClient.invalidateQueries({ queryKey: dbKeys.recordings.all });
+    queryClient.invalidateQueries({ queryKey: dbKeys.recordings.latest });
+
+    return Ok(undefined);
+  },
+}),
+```
+
+### Query Keys Pattern
+
+Organize keys hierarchically for targeted invalidation:
+
+```typescript
+export const dbKeys = {
+	recordings: {
+		all: ['db', 'recordings'] as const,
+		latest: ['db', 'recordings', 'latest'] as const,
+		byId: (id: string) => ['db', 'recordings', id] as const,
+	},
+	transformations: {
+		all: ['db', 'transformations'] as const,
+		byId: (id: string) => ['db', 'transformations', id] as const,
+	},
+};
+```
+
+## Query Definition Examples
+
+### Basic Query
+
+```typescript
+export const db = {
+	recordings: {
+		getAll: defineQuery({
+			queryKey: dbKeys.recordings.all,
+			queryFn: () => services.db.recordings.getAll(),
+		}),
+	},
+};
+```
+
+### Query with Initial Data
+
+```typescript
+getLatest: defineQuery({
+  queryKey: dbKeys.recordings.latest,
+  queryFn: () => services.db.recordings.getLatest(),
+  // Use cached data if available
+  initialData: () =>
+    queryClient
+      .getQueryData<Recording[]>(dbKeys.recordings.all)
+      ?.toSorted((a, b) =>
+        new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+      )[0] ?? null,
+  initialDataUpdatedAt: () =>
+    queryClient.getQueryState(dbKeys.recordings.all)?.dataUpdatedAt,
+}),
+```
+
+### Parameterized Query with Accessor
+
+```typescript
+getById: (id: Accessor<string>) =>
+  defineQuery({
+    queryKey: dbKeys.recordings.byId(id()),
+    queryFn: () => services.db.recordings.getById(id()),
+    initialData: () =>
+      queryClient
+        .getQueryData<Recording[]>(dbKeys.recordings.all)
+        ?.find((r) => r.id === id()) ?? null,
+  }),
+```
+
+### Mutation with Callbacks
+
+```typescript
+startRecording: defineMutation({
+  mutationKey: recorderKeys.startRecording,
+  mutationFn: async ({ toastId }) => {
+    const { data, error } = await recorderService().startRecording(params, {
+      sendStatus: (options) => notify.loading.execute({ id: toastId, ...options }),
+    });
+
+    if (error) {
+      return Err({
+        title: '❌ Failed to start recording',
+        description: error.message,
+        action: { type: 'more-details', error },
+      });
+    }
+    return Ok(data);
+  },
+  // Invalidate state after mutation completes
+  onSettled: () => queryClient.invalidateQueries({ queryKey: recorderKeys.recorderState }),
+}),
+```
+
+## RPC Namespace
+
+All queries are bundled into a unified `rpc` namespace:
+
+```typescript
+// query/index.ts
+export const rpc = {
+	db,
+	recorder,
+	transcription,
+	clipboard,
+	sound,
+	analytics,
+	notify,
+	// ... all feature modules
+} as const;
+
+// Usage anywhere in the app
+import { rpc } from '$lib/query';
+
+// Reactive (in components)
+const query = createQuery(() => rpc.db.recordings.getAll.options);
+
+// Imperative (in handlers/workflows)
+const { data, error } = await rpc.recorder.startRecording.execute({ toastId });
+```
+
+## Notify API Example
+
+The query layer can coordinate multiple services:
+
+```typescript
+export const notify = {
+	success: defineMutation({
+		mutationFn: async (options: NotifyOptions) => {
+			// Show both toast AND OS notification
+			services.toast.success(options);
+			await services.notification.show({ ...options, variant: 'success' });
+			return Ok(undefined);
+		},
+	}),
+
+	error: defineMutation({
+		mutationFn: async (error: UserError) => {
+			services.toast.error(error);
+			await services.notification.show({ ...error, variant: 'error' });
+			return Ok(undefined);
+		},
+	}),
+
+	loading: defineMutation({
+		mutationFn: async (options: LoadingOptions) => {
+			// Only toast for loading states (no OS notification spam)
+			services.toast.loading(options);
+			return Ok(undefined);
+		},
+	}),
+};
+```
+
+## Key Rules
+
+1. **Always transform errors at query boundary** - Never return raw service errors
+2. **Use `.options` (no parentheses)** - It's a static object, wrap in accessor for Svelte
+3. **Never double-wrap errors** - Each error is wrapped exactly once
+4. **Services are pure, queries inject settings** - Services take explicit params
+5. **Use `.execute()` in `.ts` files** - `createMutation` requires component context
+6. **Update cache optimistically** - Better UX for mutations
+
+## References
+
+- See `apps/whispering/src/lib/query/README.md` for detailed architecture
+- See the `services-layer` skill for how services are implemented
+- See the `error-handling` skill for trySync/tryAsync patterns

--- a/.claude/skills/services-layer/SKILL.md
+++ b/.claude/skills/services-layer/SKILL.md
@@ -1,0 +1,617 @@
+---
+name: services-layer
+description: Service layer patterns with defineErrors, namespace exports, and Result types. Use when creating new services, defining domain-specific errors, or understanding the service architecture.
+metadata:
+  author: epicenter
+  version: '3.0'
+---
+
+# Services Layer Patterns
+
+This skill documents how to implement services in the Whispering architecture. Services are pure, isolated business logic with no UI dependencies that return `Result<T, E>` types for error handling.
+
+## When to Apply This Skill
+
+Use this pattern when you need to:
+
+- Create a new service with domain-specific error handling
+- Add error types with structured context (like HTTP status codes)
+- Understand how services are organized and exported
+- Implement platform-specific service variants (desktop vs web)
+
+## Core Architecture
+
+Services follow a three-layer architecture: **Service** → **Query** → **UI**
+
+```
+┌─────────────┐     ┌─────────────┐     ┌──────────────┐
+│     UI      │ --> │  RPC/Query  │ --> │   Services   │
+│ Components  │     │    Layer    │     │    (Pure)    │
+└─────────────┘     └─────────────┘     └──────────────┘
+```
+
+**Services are:**
+
+- **Pure**: Accept explicit parameters, no hidden dependencies
+- **Isolated**: No knowledge of UI state, settings, or reactive stores
+- **Testable**: Easy to unit test with mock parameters
+- **Consistent**: All return `Result<T, E>` types for uniform error handling
+
+## Creating Errors with defineErrors
+
+Every service defines domain-specific errors using `defineErrors` from wellcrafted. Errors are grouped into a namespace object where each key becomes a variant.
+
+```typescript
+import { defineErrors, type InferError, type InferErrors, extractErrorMessage } from 'wellcrafted/error';
+import { Err, Ok, type Result, tryAsync, trySync } from 'wellcrafted/result';
+
+// Namespace-style error definition — name describes the domain
+const CompletionError = defineErrors({
+  ConnectionFailed: ({ cause }: { cause: unknown }) => ({
+    message: `Connection failed: ${extractErrorMessage(cause)}`,
+    cause,
+  }),
+  EmptyResponse: ({ providerLabel }: { providerLabel: string }) => ({
+    message: `${providerLabel} API returned an empty response`,
+    providerLabel,
+  }),
+  MissingParam: ({ param }: { param: string }) => ({
+    message: `${param} is required`,
+    param,
+  }),
+});
+
+// Type derivation — shadow the const with a type of the same name
+type CompletionError = InferErrors<typeof CompletionError>;
+type ConnectionFailedError = InferError<typeof CompletionError.ConnectionFailed>;
+
+// Call sites — each variant returns Err<...> directly
+return CompletionError.ConnectionFailed({ cause: error });
+return CompletionError.EmptyResponse({ providerLabel: 'OpenAI' });
+return CompletionError.MissingParam({ param: 'apiKey' });
+```
+
+### How defineErrors Works
+
+`defineErrors({ ... })` takes an object of factory functions and returns a namespace object. Each key becomes a variant:
+
+- **`name` is auto-stamped** from the key (e.g., key `NotFound` → `error.name === 'NotFound'`)
+- **The factory function IS the message generator** — it returns `{ message, ...fields }`
+- **Each variant returns `Err<...>` directly** — no separate `FooErr` constructor needed
+- **Types use `InferError` / `InferErrors`** — not `ReturnType`
+
+```typescript
+// No-input variant (static message)
+const RecorderError = defineErrors({
+  Busy: () => ({
+    message: 'A recording is already in progress',
+  }),
+});
+
+// Usage — no arguments needed
+return RecorderError.Busy();
+
+// Variant with derived fields — constructor extracts from raw input
+const HttpError = defineErrors({
+  Response: ({ response, body }: { response: { status: number }; body: unknown }) => ({
+    message: `HTTP ${response.status}: ${extractErrorMessage(body)}`,
+    status: response.status,
+    body,
+  }),
+});
+
+// Usage — pass raw objects, constructor derives fields
+return HttpError.Response({ response, body: await response.json() });
+// error.message → "HTTP 401: Unauthorized"
+// error.status  → 401 (derived from response, flat on the object)
+// error.name    → "Response"
+```
+
+### Error Type Examples from the Codebase
+
+```typescript
+// Static message, no input needed
+const RecorderError = defineErrors({
+  Busy: () => ({
+    message: 'A recording is already in progress',
+  }),
+});
+RecorderError.Busy()
+
+// Multiple related errors in a single namespace
+const HttpError = defineErrors({
+  Connection: ({ cause }: { cause: unknown }) => ({
+    message: `Failed to connect to the server: ${extractErrorMessage(cause)}`,
+    cause,
+  }),
+  Response: ({ response, body }: { response: { status: number }; body: unknown }) => ({
+    message: `HTTP ${response.status}: ${extractErrorMessage(body)}`,
+    status: response.status,
+    body,
+  }),
+  Parse: ({ cause }: { cause: unknown }) => ({
+    message: `Failed to parse response body: ${extractErrorMessage(cause)}`,
+    cause,
+  }),
+});
+
+// Union type for the whole namespace
+type HttpError = InferErrors<typeof HttpError>;
+
+// Individual variant type
+type ConnectionError = InferError<typeof HttpError.Connection>;
+```
+
+## Anti-Pattern: Discriminated Union Inputs
+
+**String literal unions inside error factory inputs are a code smell.** When a variant's input contains a field like `reason: 'a' | 'b' | 'c'` or `operation: 'x' | 'y' | 'z'`, you're creating a sub-discriminant that duplicates what `defineErrors` already provides at the top level.
+
+### The Problem
+
+```typescript
+// BAD: Sub-discriminant forces double narrowing and dishonest types
+const ShortcutError = defineErrors({
+  InvalidAccelerator: (input: {
+    reason: 'invalid_format' | 'no_key_code' | 'multiple_key_codes';
+    accelerator?: string;  // Optional because some reasons don't use it
+  }) => {
+    const messages = {
+      invalid_format: `Invalid format: '${input.accelerator}'`,
+      no_key_code: 'No valid key code found',
+      multiple_key_codes: 'Multiple key codes not allowed',
+    };
+    return { message: messages[input.reason], ...input };
+  },
+});
+```
+
+**Why this is bad:**
+1. **Double narrowing**: Consumers must narrow on `error.name` then on `error.reason`
+2. **Dishonest types**: `accelerator` is optional because some reasons don't need it, but the type doesn't express which ones do
+3. **Obscured intent**: The `reason` field is doing the discriminant's job — that's what variant names are for
+
+### The Fix: Split Into Separate Variants
+
+```typescript
+// GOOD: Each variant has exactly the fields it needs
+const ShortcutError = defineErrors({
+  InvalidFormat: ({ accelerator }: { accelerator: string }) => ({
+    message: `Invalid accelerator format: '${accelerator}'`,
+    accelerator,
+  }),
+  NoKeyCode: () => ({
+    message: 'No valid key code found in pressed keys',
+  }),
+  MultipleKeyCodes: () => ({
+    message: 'Multiple key codes not allowed in accelerator',
+  }),
+});
+```
+
+**Why this is better:**
+- **Single narrowing**: `error.name === 'NoKeyCode'` — done
+- **Honest types**: `InvalidFormat` requires `accelerator`, `NoKeyCode` takes nothing
+- **Self-documenting**: Variant names describe the error, no lookup table needed
+
+### When This Applies
+
+Split whenever you see:
+- `reason: 'a' | 'b' | 'c'` with a message lookup table
+- `operation: 'x' | 'y' | 'z'` with different messages per operation
+- `errorKind: ...` or `type: ...` acting as a sub-discriminant
+- Optional fields that exist because "some variants" don't use them
+
+The whole point of `defineErrors` is that each variant is a first-class citizen with its own name and shape. Collapsing them behind string unions saves a few lines of definition at the cost of weaker types and double-narrowing at every consumer.
+
+### Exception: When It's Genuinely One Error
+
+If the string literal truly is a *field* and not a sub-discriminant — e.g., the consumer doesn't switch on it — then it's fine:
+
+```typescript
+// OK: 'operation' is metadata for logging, not a sub-discriminant
+const FsError = defineErrors({
+  ReadFailed: ({ path, cause }: { path: string; cause: unknown }) => ({
+    message: `Failed to read '${path}': ${extractErrorMessage(cause)}`,
+    path,
+    cause,
+  }),
+  WriteFailed: ({ path, cause }: { path: string; cause: unknown }) => ({
+    message: `Failed to write '${path}': ${extractErrorMessage(cause)}`,
+    path,
+    cause,
+  }),
+});
+```
+
+## Anti-Pattern: Conditional Logic on Factory Inputs
+
+**If a variant constructor uses if/switch on its own input fields to decide the message or behavior, each branch should be its own variant.** This is a generalization of the string literal union rule above — any branching inside a constructor means multiple errors are hiding in one variant.
+
+### The Problem
+
+```typescript
+// BAD: Constructor branches on inputs — multiple errors hiding in one variant
+const FormError = defineErrors({
+  Validation: ({ field, value, receivedType }: {
+    field?: string;     // Optional because not every branch uses it
+    value?: string;     // Optional because not every branch uses it
+    receivedType?: string; // Optional because not every branch uses it
+  }) => ({
+    message: (() => {
+      if (field === 'email' && value) return `Invalid email address: '${value}'`;
+      if (field === 'password' && value)
+        return `Password too weak: must be at least 8 characters`;
+      if (field === 'confirmPassword')
+        return 'Passwords do not match';
+      if (receivedType) return `Invalid form data: expected string, got ${receivedType}`;
+      return 'Form submission failed';
+    })(),
+    field,
+    value,
+    receivedType,
+  }),
+});
+```
+
+**Symptoms:**
+1. **Dishonest optionals**: Fields are optional because no single call site uses them all — the type lies about what each error actually carries
+2. **Hidden branching**: Consumers must inspect fields beyond `name` to know the real error kind — `name === 'Validation'` tells you nothing
+3. **Untypeable messages**: The message depends on runtime field combinations, so TypeScript can't narrow to a specific message shape
+
+### The Fix: Flatten Each Branch Into Its Own Variant
+
+```typescript
+// GOOD: Each branch becomes its own variant with honest, required fields
+const FormError = defineErrors({
+  InvalidEmail: ({ value }: { value: string }) => ({
+    message: `Invalid email address: '${value}'`,
+    value,
+  }),
+  WeakPassword: () => ({
+    message: 'Password too weak: must be at least 8 characters',
+  }),
+  PasswordMismatch: () => ({
+    message: 'Passwords do not match',
+  }),
+  InvalidFormData: ({ receivedType }: { receivedType: string }) => ({
+    message: `Invalid form data: expected string, got ${receivedType}`,
+    receivedType,
+  }),
+  SubmissionFailed: () => ({
+    message: 'Form submission failed',
+  }),
+});
+```
+
+**Why this is better:**
+- **Honest types**: `InvalidEmail` requires `value`, `WeakPassword` takes nothing — no dishonest optionals
+- **Single narrowing**: `error.name === 'InvalidEmail'` tells you everything
+- **Typeable messages**: Each variant has a deterministic message shape
+
+### Rule of Thumb
+
+If the constructor branches on its inputs to decide the message, each branch should be its own variant. The branching *is* the evidence that you have multiple distinct errors collapsed into one.
+
+This applies to:
+- **If/else chains** in message construction (including IIFEs)
+- **Switch statements** on input fields
+- **Ternary expressions** that pick between fundamentally different messages
+- **Lookup tables** keyed on input fields (covered by the string literal union rule above)
+
+> See also: `docs/core/error-system.mdx` § "3b. Avoid Conditional Logic on Factory Inputs" for the canonical reference with full examples.
+
+## Service Implementation Pattern
+
+### Basic Service Structure
+
+```typescript
+import { defineErrors, type InferErrors, extractErrorMessage } from 'wellcrafted/error';
+import { Err, Ok, type Result, tryAsync, trySync } from 'wellcrafted/result';
+
+// 1. Define domain-specific errors — variant names describe failure modes
+const AutostartError = defineErrors({
+  CheckFailed: ({ cause }: { cause: unknown }) => ({
+    message: `Failed to check autostart: ${extractErrorMessage(cause)}`,
+    cause,
+  }),
+  EnableFailed: ({ cause }: { cause: unknown }) => ({
+    message: `Failed to enable autostart: ${extractErrorMessage(cause)}`,
+    cause,
+  }),
+  DisableFailed: ({ cause }: { cause: unknown }) => ({
+    message: `Failed to disable autostart: ${extractErrorMessage(cause)}`,
+    cause,
+  }),
+});
+type AutostartError = InferErrors<typeof AutostartError>;
+
+// 2. Create factory function that returns service object
+export function createAutostartService() {
+	return {
+		async isEnabled(): Promise<Result<boolean, AutostartError>> {
+			return tryAsync({
+				try: () => isEnabled(),
+				catch: (error) =>
+					AutostartError.CheckFailed({ cause: error }),
+			});
+		},
+		async enable(): Promise<Result<void, AutostartError>> {
+			return tryAsync({
+				try: () => enable(),
+				catch: (error) =>
+					AutostartError.EnableFailed({ cause: error }),
+			});
+		},
+	};
+}
+
+// 3. Export the "Live" instance (production singleton)
+export type AutostartService = ReturnType<typeof createAutostartService>;
+export const AutostartServiceLive = createAutostartService();
+```
+
+### Real-World Example: Recorder Service
+
+```typescript
+// From apps/whispering/src/lib/services/isomorphic/recorder/navigator.ts
+
+const RecorderError = defineErrors({
+  AlreadyRecording: () => ({
+    message: 'A recording is already in progress. Please stop the current recording.',
+  }),
+  StreamAcquisition: ({ cause }: { cause: unknown }) => ({
+    message: `Failed to acquire recording stream: ${extractErrorMessage(cause)}`,
+    cause,
+  }),
+  InitFailed: ({ cause }: { cause: unknown }) => ({
+    message: `Failed to initialize recorder. ${extractErrorMessage(cause)}`,
+    cause,
+  }),
+});
+type RecorderError = InferErrors<typeof RecorderError>;
+
+export function createNavigatorRecorderService(): RecorderService {
+	let activeRecording: ActiveRecording | null = null;
+
+	return {
+		getRecorderState: async (): Promise<
+			Result<WhisperingRecordingState, RecorderError>
+		> => {
+			return Ok(activeRecording ? 'RECORDING' : 'IDLE');
+		},
+
+		startRecording: async (
+			params: NavigatorRecordingParams,
+			{ sendStatus },
+		): Promise<Result<DeviceAcquisitionOutcome, RecorderError>> => {
+			// Validate state
+			if (activeRecording) {
+				return RecorderError.AlreadyRecording();
+			}
+
+			// Get stream (calls another service)
+			const { data: streamResult, error: acquireStreamError } =
+				await getRecordingStream({ selectedDeviceId, sendStatus });
+
+			if (acquireStreamError) {
+				return RecorderError.StreamAcquisition({
+					cause: acquireStreamError,
+				});
+			}
+
+			// Initialize MediaRecorder
+			const { data: mediaRecorder, error: recorderError } = trySync({
+				try: () =>
+					new MediaRecorder(stream, {
+						bitsPerSecond: Number(bitrateKbps) * 1000,
+					}),
+				catch: (error) =>
+					RecorderError.InitFailed({ cause: error }),
+			});
+
+			if (recorderError) {
+				cleanupRecordingStream(stream);
+				return Err(recorderError);
+			}
+
+			// Store state and start
+			activeRecording = {
+				recordingId,
+				stream,
+				mediaRecorder,
+				recordedChunks: [],
+			};
+			mediaRecorder.start(TIMESLICE_MS);
+
+			return Ok(deviceOutcome);
+		},
+	};
+}
+
+export const NavigatorRecorderServiceLive = createNavigatorRecorderService();
+```
+
+## Namespace Exports Pattern
+
+Services are organized hierarchically and re-exported as namespace objects:
+
+### Folder Structure
+
+```
+services/
+├── desktop/           # Desktop-only (Tauri)
+│   ├── index.ts       # Re-exports as desktopServices
+│   ├── command.ts
+│   └── ffmpeg.ts
+├── isomorphic/        # Cross-platform
+│   ├── index.ts       # Re-exports as services
+│   ├── transcription/
+│   │   ├── index.ts   # Re-exports as transcriptions namespace
+│   │   ├── cloud/
+│   │   │   ├── openai.ts
+│   │   │   └── groq.ts
+│   │   └── local/
+│   │       └── whispercpp.ts
+│   └── completion/
+│       ├── index.ts
+│       └── openai.ts
+├── types.ts
+└── index.ts           # Main entry point
+```
+
+### Index File Pattern
+
+```typescript
+// services/isomorphic/transcription/index.ts
+export { OpenaiTranscriptionServiceLive as openai } from './cloud/openai';
+export { GroqTranscriptionServiceLive as groq } from './cloud/groq';
+export { WhispercppTranscriptionServiceLive as whispercpp } from './local/whispercpp';
+
+// services/isomorphic/index.ts
+import * as transcriptions from './transcription';
+import * as completions from './completion';
+
+export const services = {
+	db: DbServiceLive,
+	sound: PlaySoundServiceLive,
+	transcriptions, // Namespace import
+	completions, // Namespace import
+} as const;
+
+// services/index.ts (main entry)
+export { services } from './isomorphic';
+export { desktopServices } from './desktop';
+```
+
+### Consuming Services
+
+```typescript
+// In query layer or anywhere
+import { services, desktopServices } from '$lib/services';
+
+// Access via namespace
+await services.transcriptions.openai.transcribe(blob, options);
+await services.transcriptions.groq.transcribe(blob, options);
+await services.db.recordings.getAll();
+await desktopServices.ffmpeg.compressAudioBlob(blob, options);
+```
+
+## Platform-Specific Services
+
+For services that need different implementations per platform:
+
+### Define Shared Interface
+
+```typescript
+// services/isomorphic/text/types.ts
+export type TextService = {
+	readFromClipboard(): Promise<Result<string | null, TextError>>;
+	copyToClipboard(text: string): Promise<Result<void, TextError>>;
+	writeToCursor(text: string): Promise<Result<void, TextError>>;
+};
+```
+
+### Implement Per Platform
+
+```typescript
+// services/isomorphic/text/desktop.ts
+const TextError = defineErrors({
+  ClipboardWriteFailed: ({ cause }: { cause: unknown }) => ({
+    message: `Clipboard write failed: ${extractErrorMessage(cause)}`,
+    cause,
+  }),
+});
+
+export function createTextServiceDesktop(): TextService {
+	return {
+		copyToClipboard: (text) =>
+			tryAsync({
+				try: () => writeText(text), // Tauri API
+				catch: (error) =>
+					TextError.ClipboardWriteFailed({ cause: error }),
+			}),
+	};
+}
+
+// services/isomorphic/text/web.ts
+export function createTextServiceWeb(): TextService {
+	return {
+		copyToClipboard: (text) =>
+			tryAsync({
+				try: () => navigator.clipboard.writeText(text), // Browser API
+				catch: (error) =>
+					TextError.ClipboardWriteFailed({ cause: error }),
+			}),
+	};
+}
+```
+
+### Build-Time Platform Detection
+
+```typescript
+// services/isomorphic/text/index.ts
+export const TextServiceLive = window.__TAURI_INTERNALS__
+	? createTextServiceDesktop()
+	: createTextServiceWeb();
+```
+
+## Error Message Best Practices
+
+Write error messages that are:
+
+- **User-friendly**: Explain what happened in plain language
+- **Actionable**: Suggest what the user can do
+- **Detailed**: Include technical details for debugging
+
+### Choosing the right approach
+
+- **No-input variants** for static messages (e.g., `Busy: () => ({ message: '...' })`)
+- **Field-based variants** when the message is computed from structured input
+- **Separate variants** when different error conditions need different fields (see Anti-Pattern section above)
+
+```typescript
+const RecorderError = defineErrors({
+  // Static message — no input needed
+  Busy: () => ({
+    message: 'A recording is already in progress',
+  }),
+
+  // Message computed from fields
+  HttpResponse: ({ status }: { status: number }) => ({
+    message: `HTTP ${status} response`,
+    status,
+  }),
+
+  // Wrapping an unknown cause with context
+  MicrophoneUnavailable: ({ cause }: { cause: unknown }) => ({
+    message: `Unable to connect to the selected microphone: ${extractErrorMessage(cause)}`,
+    cause,
+  }),
+
+  // User-actionable message with file context
+  ConfigParseFailed: ({ filename, cause }: { filename: string; cause: unknown }) => ({
+    message: `Failed to parse configuration file. Please check that ${filename} contains valid JSON. ${extractErrorMessage(cause)}`,
+    filename,
+    cause,
+  }),
+});
+```
+
+## Key Rules
+
+1. **Services never import settings** - Pass configuration as parameters
+2. **Services never import UI code** - No toasts, no notifications, no WhisperingError
+3. **Always return Result types** - Never throw errors
+4. **Use trySync/tryAsync** - See the error-handling skill for details
+5. **Export factory + Live instance** - Factory for testing, Live for production
+6. **Use defineErrors namespaces** - Group related errors under a single namespace
+7. **Derive types with InferError/InferErrors** - Not `ReturnType`
+8. **Variant names describe the failure mode** - Never use generic names like `Service`, `Error`, or `Failed`. The namespace provides domain context (`RecorderError`), so the variant must say *what went wrong* (`AlreadyRecording`, `InitFailed`, `StreamAcquisition`). `RecorderError.Service` is meaningless — `RecorderError.AlreadyRecording` tells you exactly what happened.
+9. **Split discriminated union inputs** - Each variant gets its own name and shape. If the constructor branches on its inputs (if/switch/ternary) to decide the message, each branch should be its own variant
+10. **Transform cause in the constructor, not the call site** - Accept `cause: unknown` and call `extractErrorMessage(cause)` inside the factory's message template. Call sites pass the raw error: `{ cause: error }`. This centralizes message extraction where the message is composed and keeps call sites clean.
+
+## References
+
+- See `apps/whispering/src/lib/services/README.md` for architecture details
+- See the `query-layer` skill for how services are consumed
+- See the `error-handling` skill for trySync/tryAsync patterns

--- a/.claude/skills/single-or-array-pattern/SKILL.md
+++ b/.claude/skills/single-or-array-pattern/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: single-or-array-pattern
+description: Pattern for functions that accept either a single item or an array. Use when creating CRUD operations, batch processing APIs, or factory functions that should flexibly handle one or many inputs.
+metadata:
+  author: epicenter
+  version: '1.0'
+---
+
+# Single-or-Array Pattern
+
+Accept both single items and arrays, normalize at the top, process uniformly.
+
+## Quick Reference
+
+```typescript
+function create(itemOrItems: T | T[]): Promise<Result<void, E>> {
+	const items = Array.isArray(itemOrItems) ? itemOrItems : [itemOrItems];
+	// ... implementation works on items array
+}
+```
+
+## The Structure
+
+1. **Accept `T | T[]`** as the parameter type
+2. **Normalize** with `Array.isArray()` at the top of the function
+3. **All logic** works against the array — one code path
+
+```typescript
+function createServer(clientOrClients: Client | Client[], options?: Options) {
+	const clients = Array.isArray(clientOrClients)
+		? clientOrClients
+		: [clientOrClients];
+
+	// All real logic here, working with the array
+	for (const client of clients) {
+		// ...
+	}
+}
+```
+
+## Naming Conventions
+
+| Parameter               | Normalized Variable |
+| ----------------------- | ------------------- |
+| `recordingOrRecordings` | `recordings`        |
+| `clientOrClients`       | `clients`           |
+| `itemOrItems`           | `items`             |
+| `paramsOrParamsArray`   | `paramsArray`       |
+
+## When to Use
+
+**Good fit:**
+
+- CRUD operations (create, update, delete)
+- Batch processing APIs
+- Factory functions accepting dependencies
+- Any "do this to one or many" scenario
+
+**Skip when:**
+
+- Single vs batch have different semantics
+- Return types vary significantly
+- Array version needs different options
+
+## Codebase Examples
+
+### Server Factory (`packages/server/src/server.ts`)
+
+```typescript
+function createServer(
+	clientOrClients: AnyWorkspaceClient | AnyWorkspaceClient[],
+	options?: ServerOptions,
+) {
+	const clients = Array.isArray(clientOrClients)
+		? clientOrClients
+		: [clientOrClients];
+
+	// All server setup logic directly here
+	const workspaces: Record<string, AnyWorkspaceClient> = {};
+	for (const client of clients) {
+		workspaces[client.id] = client;
+	}
+	// ...
+}
+```
+
+### Database Service (`apps/whispering/src/lib/services/isomorphic/db/web.ts`)
+
+```typescript
+delete: async (recordingOrRecordings) => {
+  const recordings = Array.isArray(recordingOrRecordings)
+    ? recordingOrRecordings
+    : [recordingOrRecordings];
+  const ids = recordings.map((r) => r.id);
+  return tryAsync({
+    try: () => db.recordings.bulkDelete(ids),
+    catch: (error) => DbError.MutationFailed({ cause: error }),
+  });
+},
+```
+
+### Query Mutations (`apps/whispering/src/lib/query/isomorphic/db.ts`)
+
+```typescript
+delete: defineMutation({
+  mutationFn: async (recordings: Recording | Recording[]) => {
+    const recordingsArray = Array.isArray(recordings)
+      ? recordings
+      : [recordings];
+
+    for (const recording of recordingsArray) {
+      services.db.recordings.revokeAudioUrl(recording.id);
+    }
+
+    const { error } = await services.db.recordings.delete(recordingsArray);
+    if (error) return Err(error);
+    return Ok(undefined);
+  },
+}),
+```
+
+## Anti-Patterns
+
+### Don't: Separate functions for single vs array
+
+```typescript
+// Harder to maintain, users must remember two APIs
+function createRecording(recording: Recording): Promise<...>;
+function createRecordings(recordings: Recording[]): Promise<...>;
+```
+
+### Don't: Force arrays everywhere
+
+```typescript
+// Awkward for single items
+createRecordings([recording]); // Ugly
+```
+
+### Don't: Duplicate logic in overloads
+
+```typescript
+// BAD: Logic duplicated
+function create(item: T) {
+	return db.insert(item); // Duplicated
+}
+function create(items: T[]) {
+	return db.bulkInsert(items); // Different code path
+}
+
+// GOOD: Single implementation
+function create(itemOrItems: T | T[]) {
+	const items = Array.isArray(itemOrItems) ? itemOrItems : [itemOrItems];
+	return db.bulkInsert(items); // One code path
+}
+```
+
+## References
+
+- [Full article](../../docs/articles/single-or-array-overload-pattern.md) — detailed explanation with more examples

--- a/.claude/skills/spec-execution/SKILL.md
+++ b/.claude/skills/spec-execution/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: spec-execution
+description: Execute a specification document through planned waves of parallel and sequential changes, updating the spec and committing after each wave. Use when given a spec to implement, executing a planning document, or told to "execute this spec".
+---
+
+# Spec Execution
+
+When handed a specification document (a `specs/*.md` file), execute it methodically in waves. Each wave produces working code, an updated spec, and a commit. The goal is a clean git history where each commit represents a coherent unit of progress against the spec.
+
+## The Execution Loop
+
+```
+READ SPEC
+    ↓
+PLAN WAVES (which tasks are parallel vs sequential?)
+    ↓
+┌─── WAVE N ──────────────────────────────────────┐
+│  1. Execute tasks (sub-agents for ALL tasks)     │
+│  2. Verify (type-check, tests if applicable)     │
+│  3. Update spec (check off items, add notes)     │
+│  4. Commit (code changes + spec updates)         │
+└──────────────────────────────────────────────────┘
+    ↓
+REPEAT until spec is complete
+    ↓
+FINAL REVIEW (update spec status, add review section)
+```
+
+## Phase 1: Read and Understand
+
+Before touching any code:
+
+1. **Read the entire spec** — understand the full scope before planning
+2. **Identify the implementation phases** from the spec's Implementation Plan section
+3. **Map dependencies** — which tasks block others? Which are independent?
+4. **Check the spec's Open Questions** — resolve what you can, flag what needs human input
+
+If the spec has unresolved Open Questions that block implementation, surface them immediately. Don't guess on architectural decisions.
+
+## Phase 2: Plan Waves
+
+Break the spec's implementation plan into execution waves. A wave is a set of changes that can be made together without breaking anything.
+
+### Deciding Parallel vs Sequential
+
+Every task runs in a sub-agent regardless. The question is only whether sub-agents run concurrently or one-at-a-time.
+
+| Condition | Ordering |
+| --- | --- |
+| Tasks touch different files/modules | Parallel |
+| Task B imports from Task A's output | Sequential (A before B) |
+| Tasks modify the same file | Sequential (avoid conflicts) |
+| Tasks are in different spec phases | Sequential (phase order) |
+| Tasks within a phase are independent | Parallel |
+
+### Wave Planning Checklist
+
+Before executing, write out your wave plan:
+
+```
+Wave 1: [Foundation — types and interfaces]
+  - Task 1.1 (parallel with 1.2)
+  - Task 1.2 (parallel with 1.1)
+
+Wave 2: [Core logic — depends on Wave 1 types]
+  - Task 2.1 (sequential — modifies shared module)
+  - Task 2.2 (after 2.1 — uses its exports)
+
+Wave 3: [Integration — consumers of Wave 2]
+  - Task 3.1 (parallel with 3.2)
+  - Task 3.2 (parallel with 3.1)
+```
+
+Present this plan to the user before executing. Get a thumbs up.
+
+## Phase 3: Execute Waves
+
+For each wave:
+
+### 1. Execute Tasks
+
+**Every task gets its own sub-agent.** This is non-negotiable. Sub-agents exist to scope context — each one sees only what it needs for its task, which produces better results than a single agent juggling everything. Parallelism is a bonus, not the reason for sub-agents.
+
+- **Independent tasks**: Launch sub-agents in parallel. Each gets a focused prompt with only the context it needs — the relevant spec section, the files to modify, and the patterns to follow.
+- **Dependent tasks**: Launch sub-agents sequentially. Wait for one to complete before launching the next. The second agent gets the output/context from the first.
+- **Keep changes minimal**: Each task should do exactly what the spec says. No bonus refactors, no "while I'm here" improvements.
+
+### 2. Verify the Wave
+
+After all tasks in a wave complete:
+
+```bash
+bun run tsc --noEmit          # type-check
+bun test                       # if tests exist for changed code
+```
+
+If verification fails, fix issues before proceeding. Don't carry broken state into the next wave.
+
+### 3. Update the Spec
+
+Check off completed items in the spec's Implementation Plan:
+
+```markdown
+- [x] **1.1** Add IconDefinition type ← was [ ], now [x]
+- [x] **1.2** Add CoverDefinition type
+- [ ] **2.1** Update factory functions  ← not yet
+```
+
+If implementation deviated from the spec (it often does), add a note:
+
+```markdown
+- [x] **1.1** Add IconDefinition type
+  > **Note**: Used discriminated union instead of enum as originally planned.
+  > Rationale: better type narrowing in consumers.
+```
+
+If you discovered something during implementation, add it to the spec's Research Findings or Edge Cases section.
+
+### 4. Commit the Wave
+
+Each commit includes BOTH the code changes AND the spec updates. This means every commit in the history shows what was planned and what was actually done.
+
+Follow `git` and `incremental-commits` skill conventions:
+
+```
+feat(scope): wave description — what this wave accomplishes
+
+- Completed spec items 1.1, 1.2
+- [Any notable deviations or discoveries]
+```
+
+Stage specific files — never `git add .` or `git add -A`.
+
+## Phase 4: Final Review
+
+After all waves complete:
+
+1. **Update spec status** from "In Progress" to "Implemented"
+2. **Add a Review section** at the bottom of the spec:
+
+```markdown
+## Review
+
+**Completed**: [Date]
+**Branch**: [branch-name]
+
+### Summary
+
+[2-3 sentences on what was built and how it differs from the original plan]
+
+### Deviations from Spec
+
+- [What changed and why]
+
+### Follow-up Work
+
+- [Anything discovered during implementation that should be a future spec]
+```
+
+3. **Final commit** with the review section added
+
+## Sub-Agent Prompts
+
+Every task — parallel or sequential — runs in a sub-agent. The primary agent orchestrates: it plans waves, launches sub-agents, verifies results, updates the spec, and commits. It does not implement code directly.
+
+When spinning up sub-agents, each agent needs:
+
+- **The specific spec section** it's implementing (not the whole spec)
+- **The files it should read** before making changes
+- **The files it should modify** (and only those files)
+- **The patterns to follow** (reference relevant skills)
+- **What NOT to do** — stay in lane, don't touch other files
+
+Keep sub-agent prompts focused. A sub-agent that knows too much will try to do too much.
+
+## When Things Go Wrong
+
+| Situation | Response |
+| --- | --- |
+| Type-check fails after a wave | Fix before committing. Don't carry broken state. |
+| Sub-agent made changes outside its scope | Revert the out-of-scope changes. Keep only what was asked for. |
+| Spec item is ambiguous mid-implementation | Stop. Ask the user. Add clarification to the spec. |
+| Discovery invalidates a later spec phase | Update the spec's plan. Inform the user. Re-plan remaining waves. |
+| Tests fail | Fix the tests or the code. Update spec if the test failure reveals a spec gap. |
+
+## Anti-Patterns
+
+### Execute Without Planning
+
+```
+"Let me just start implementing..."
+```
+
+No. Read the spec. Plan waves. Get approval. Then execute.
+
+### Giant Wave
+
+```
+Wave 1: Implement everything in the spec
+```
+
+If a wave touches more than 5-8 files, it's too big. Break it down.
+
+### Spec Drift
+
+```
+Code diverges from spec but spec is never updated
+```
+
+The spec is a living document. Every commit should leave the spec accurate to what was actually built.
+
+### Over-Parallel
+
+```
+Wave 1: 12 sub-agents all running at once
+```
+
+More than 3-4 parallel sub-agents gets chaotic. Group related tasks and keep parallelism manageable.
+
+## Quick Reference
+
+Before starting:
+
+- [ ] Read entire spec
+- [ ] Identify phases and dependencies
+- [ ] Plan waves (parallel vs sequential)
+- [ ] Present plan to user
+
+For each wave:
+
+- [ ] Execute tasks (every task in a sub-agent)
+- [ ] Verify (type-check, tests)
+- [ ] Update spec (check items, add notes)
+- [ ] Commit (code + spec together)
+
+After all waves:
+
+- [ ] Update spec status to Implemented
+- [ ] Add Review section
+- [ ] Final commit

--- a/.claude/skills/specification-writing/SKILL.md
+++ b/.claude/skills/specification-writing/SKILL.md
@@ -1,0 +1,299 @@
+---
+name: specification-writing
+description: Write technical specifications that give agents enough context to implement features while leaving room for autonomous research and decision-making. Use when planning features, documenting architecture decisions, or creating implementation guides.
+---
+
+# Specification Writing
+
+Follow [writing-voice](../writing-voice/SKILL.md) for prose sections.
+
+A specification gives an agent (or human) the context they need to implement a feature autonomously. The goal is NOT to describe everything exhaustively; it's to provide enough initial context that the implementer can do their own research and make informed decisions.
+
+> **Note**: This guide uses `[PLACEHOLDER]` markers for content you must fill in. Code blocks show templates; replace all bracketed content with your feature's details.
+
+## The Core Philosophy
+
+Specs should:
+
+- **Provide context, not instructions**: Give the "why" and "what", let the implementer figure out "how"
+- **Document research, not conclusions**: Show what was explored, what exists, what doesn't
+- **Leave questions open**: The Open Questions section is a feature, not a bug
+- **Enable autonomous implementation**: An agent reading this should spawn sub-agents to verify and extend
+
+A good spec is a launching pad, not a script to follow.
+
+---
+
+## Document Structure
+
+### Header (Required)
+
+```markdown
+# [Feature Name]
+
+**Date**: [YYYY-MM-DD]
+**Status**: Draft | In Progress | Implemented
+**Author**: [Name or AI-assisted]
+**Branch**: [optional: feat/feature-name if work has started]
+```
+
+### Overview
+
+One paragraph max. Describe what the feature does. Don't sell it.
+
+```markdown
+## Overview
+
+[One to two sentences describing what this feature adds or changes and what it enables. Be specific about the capability, not vague about benefits.]
+```
+
+### Motivation
+
+Structure as **Current State** → **Problems** → **Desired State**.
+
+```markdown
+## Motivation
+
+### Current State
+
+[Show actual code or configuration demonstrating how things work TODAY. Use real code blocks, not prose descriptions.]
+
+This creates problems:
+
+1. **[Problem Title]**: [Specific explanation of what breaks or is painful]
+2. **[Problem Title]**: [Specific explanation of what breaks or is painful]
+
+### Desired State
+
+[Brief description of what the target looks like. Can include a code snippet showing the ideal API or structure.]
+```
+
+### Research Findings
+
+This is where specs shine. Document what you FOUND, not what you assumed.
+
+```markdown
+## Research Findings
+
+### [Topic Researched]
+
+[Description of what you investigated and methodology]
+
+| [Category]    | [Dimension 1]  | [Dimension 2]    |
+| ------------- | -------------- | ---------------- |
+| [Project/Lib] | [What they do] | [Their approach] |
+| [Project/Lib] | [What they do] | [Their approach] |
+
+**Key finding**: [Your main discovery—could be that no standard exists, or that everyone does X]
+
+**Implication**: [What this means for your design decisions]
+```
+
+Include:
+
+- What similar projects do (comparison tables)
+- What you searched for but didn't find ("No Established Pattern Exists")
+- Links or references to documentation you consulted
+
+### Design Decisions
+
+Use a table for traceability. Every decision should have a rationale.
+
+```markdown
+## Design Decisions
+
+| Decision            | Choice           | Rationale                       |
+| ------------------- | ---------------- | ------------------------------- |
+| [Decision point]    | [What you chose] | [Why this over alternatives]    |
+| [Decision point]    | [What you chose] | [Why this over alternatives]    |
+| [Deferred decision] | Deferred         | [Why it's out of scope for now] |
+```
+
+### Architecture
+
+Diagrams over prose. Show relationships visually with ASCII art.
+
+```markdown
+## Architecture
+
+[Describe what the diagram shows]
+```
+
+┌─────────────────────────────────────────┐
+│ [Component Name] │
+│ ├── [field]: [type or value] │
+│ └── [field]: [type or value] │
+└─────────────────────────────────────────┘
+│
+▼ [relationship label]
+┌─────────────────────────────────────────┐
+│ [Component Name] │
+└─────────────────────────────────────────┘
+
+```
+
+```
+
+For multi-step flows:
+
+```markdown
+
+```
+
+STEP 1: [Step name]
+────────────────────
+[What happens in this step]
+
+STEP 2: [Step name]
+────────────────────
+[What happens in this step]
+
+```
+
+```
+
+### Implementation Plan
+
+Break into phases. Use checkboxes for tracking. Phase 1 should be detailed; later phases can be rougher (the implementer will flesh them out).
+
+```markdown
+## Implementation Plan
+
+### Phase 1: [Phase Name]
+
+- [ ] **1.1** [Specific, atomic task]
+- [ ] **1.2** [Specific, atomic task]
+- [ ] **1.3** [Specific, atomic task]
+
+### Phase 2: [Phase Name]
+
+- [ ] **2.1** [Higher-level task—implementer will break down]
+- [ ] **2.2** [Higher-level task]
+```
+
+### Edge Cases
+
+List scenarios that might break assumptions or need special handling.
+
+```markdown
+## Edge Cases
+
+### [Scenario Name]
+
+1. [Initial condition]
+2. [What happens]
+3. [Expected outcome or "See Open Questions"]
+
+### [Scenario Name]
+
+1. [Initial condition]
+2. [What happens]
+3. [Expected outcome]
+```
+
+### Open Questions
+
+This section signals "you decide this" to the implementer. Include your recommendation but don't close the question.
+
+```markdown
+## Open Questions
+
+1. **[Question about an unresolved design decision]**
+   - Options: (a) [Option A], (b) [Option B], (c) [Option C]
+   - **Recommendation**: [Your suggestion and why, but explicitly leave it open]
+
+2. **[Another unresolved question]**
+   - [Context about why this is uncertain]
+   - **Recommendation**: [Suggestion or "Defer until X"]
+```
+
+### Success Criteria
+
+How do we know this is done? Checkboxes for verification.
+
+```markdown
+## Success Criteria
+
+- [ ] [Specific, verifiable outcome]
+- [ ] [Specific, verifiable outcome]
+- [ ] [Tests pass / build succeeds / docs updated]
+```
+
+### References
+
+Files that will be touched or consulted.
+
+```markdown
+## References
+
+- `[path/to/file.ts]` - [Why this file is relevant]
+- `[path/to/pattern.ts]` - [Pattern to follow or reference]
+```
+
+---
+
+## Good vs Bad Specs
+
+### Good Spec Characteristics
+
+- **Research is documented**: Shows what was explored, not just conclusions
+- **Decisions have rationale**: Every choice has a "why" in a table
+- **Questions are left open**: Implementer has room to decide
+- **Code shows current state**: Not described abstractly
+- **Architecture is visual**: ASCII diagrams over prose
+- **Phases are actionable**: Checkboxes that can be tracked
+
+### Bad Spec Characteristics
+
+- **Prescriptive step-by-step**: Reads like a tutorial, no room for autonomy
+- **Assumes without research**: "We'll use X" without exploring alternatives
+- **Closes all questions**: No Open Questions section
+- **Abstract descriptions**: "The system will handle Y" without showing code
+- **Wall of prose**: No tables, no diagrams, no structure
+
+---
+
+## Writing for Agent Implementers
+
+When an agent reads your spec, they should:
+
+1. **Understand the problem** from Motivation section
+2. **Know what's been explored** from Research Findings
+3. **See the proposed direction** from Design Decisions
+4. **Have a starting point** from Implementation Plan Phase 1
+5. **Know what to investigate further** from Open Questions
+
+The agent will then:
+
+- Spawn sub-agents to verify your research
+- Explore the Open Questions you left
+- Flesh out later phases of the implementation plan
+- Make decisions where you left room
+
+If your spec is too prescriptive, the agent will blindly follow it. If it's too vague, the agent will flounder. The sweet spot is: **enough context to start, enough openness to own the implementation**.
+
+---
+
+## Quick Reference Checklist
+
+```markdown
+- [ ] Header (Date, Status, Author)
+- [ ] Overview (1-2 sentences)
+- [ ] Motivation
+  - [ ] Current State (with code)
+  - [ ] Problems (numbered)
+  - [ ] Desired State
+- [ ] Research Findings
+  - [ ] Comparison tables
+  - [ ] Key findings
+  - [ ] Implications
+- [ ] Design Decisions (table with rationale)
+- [ ] Architecture (ASCII diagrams)
+- [ ] Implementation Plan (phased checkboxes)
+- [ ] Edge Cases
+- [ ] Open Questions (with recommendations)
+- [ ] Success Criteria
+- [ ] References
+```
+
+Not every spec needs every section. A small feature might skip Research Findings. A migration spec might focus heavily on Edge Cases. Use judgment.

--- a/.claude/skills/technical-articles/SKILL.md
+++ b/.claude/skills/technical-articles/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: technical-articles
+description: Writing technical articles and blog posts. Use when creating articles in docs/articles/ or blog content explaining patterns, techniques, or lessons learned.
+---
+
+# Technical Articles
+
+All articles must follow [writing-voice](../writing-voice/SKILL.md) rules.
+
+## Core Principles
+
+Title should BE the takeaway, not a topic. "Write Context to a File, Not a Prompt" not "Context Management in Agent Workflows".
+
+Lead with a strong opening paragraph that states the key insight in plain language. Reader should get it in 5 seconds. Then go straight into code. Don't force a blockquote or pull-quote after the opening; if the insight needs a quotable summary, the opening paragraph already is one.
+
+Code speaks louder than prose. Show real examples from actual codebases, not abstract `foo`/`bar` illustrations. If the code is self-explanatory, don't over-explain.
+
+## Section Headings Are Arguments
+
+Section headings should make claims, not announce topics. The reader should know your position from the heading alone.
+
+Bad (topic headings):
+
+> ## What's in the binary
+>
+> ## How Go and Rust compare
+>
+> ## Why tree-shaking is difficult
+
+Good (argument headings):
+
+> ## Go and Rust: Your code IS the binary
+>
+> ## Bun (and Deno/Node): Your code rides on top of a VM
+>
+> ## Why tree-shaking the runtime is brutally hard
+
+The first set describes what the section is about. The second set tells you what the section argues. A reader who only skims headings should walk away with the article's core argument.
+
+This applies to the title too: "Bun Compile Is 57MB Because It's Not Your Code" is an argument. "Understanding Bun Compile Binary Size" is a topic.
+
+## Conversational Directness
+
+Write like you're explaining to a peer, not presenting to an audience. Short declarative sentences. Opinions stated plainly. Concessions acknowledged without hedging.
+
+Bad (formal article-speak):
+
+> The resulting bundle size of the `bun build --compile` command is notably large. With careful analysis, we can identify several contributing factors.
+
+Good (direct, conversational):
+
+> A `console.log("Hello World")` compiles to 57MB. Your code adds almost nothing. The binary is the entire Bun runtime.
+
+Parenthetical asides, dashes for emphasis, and sentence fragments are all fine when they serve clarity. "Stripping the JIT? Now your code runs 10-100x slower." reads better than a formally constructed alternative.
+
+## Visual Elements Are Tools, Not Checkboxes
+
+ASCII diagrams, tables, and before/after code blocks are tools to reach for when they clarify something prose can't. They are not required ingredients.
+
+Use a diagram when showing flow or architecture that's hard to describe linearly. Use a table when there's a genuine comparison with 3+ items. Use before/after code when the contrast IS the point. Skip all of them when the article doesn't need them.
+
+When you have multiple independent reasons for something, write them as regular prose with natural transitions. Don't use numbered bold headings (`**1. Bold heading**` followed by explanation)—that pattern is one of the most recognizable AI writing tells.
+
+## Rhythm and Pacing
+
+This is the most important section. Good articles alternate between prose and visuals. The reader's eye should bounce: context → code → explanation → diagram → implication. Neither prose nor code should dominate for long stretches.
+
+### The Rules
+
+1. **Max 3-4 sentences of prose before a code block, diagram, or table.** If you're writing more than that without a visual break, you're missing an opportunity.
+2. **Every code block gets 1-2 sentences of setup before it.** Don't drop code without context. But don't write a paragraph either.
+3. **After a code block, one sentence of explanation is often enough.** If the code is self-explanatory, skip it entirely and bridge to the next idea.
+4. **Use line breaks between distinct thoughts.** Don't pack three ideas into one paragraph. Each paragraph: one idea.
+
+### Good rhythm — prose and code alternate:
+
+```
+[1-2 sentences: what the problem is]
+
+\`\`\`typescript
+// code showing the problem
+const result = table.find(id);  // O(n) scan every time
+\`\`\`
+
+[1 sentence: why this is bad, bridge to solution]
+
+\`\`\`typescript
+// code showing the solution
+const result = index.get(id);   // O(1) lookup
+\`\`\`
+
+[1-2 sentences: what this means for the reader]
+```
+
+### Bad rhythm — wall of prose, code at the end:
+
+```
+[Paragraph explaining the problem]
+[Paragraph explaining the approach]
+[Paragraph explaining the implementation]
+[Paragraph explaining the result]
+
+\`\`\`typescript
+// single code block at the bottom
+\`\`\`
+```
+
+The first version lets the reader verify each claim against code as they go. The second forces them to hold four paragraphs in memory, then mentally map them to code.
+
+## Writing the Opening
+
+The opening paragraph carries the entire article. If someone reads nothing else, this paragraph should give them the insight.
+
+Bad (topic announcement):
+
+> In this article, we'll explore how context management works in agent workflows and discuss some approaches to improving it.
+
+Good (insight up front):
+
+> Write your context to a file, not a prompt. When a conversation spawns sub-agents, each one starts with a blank slate. If the context lives in a spec file on disk, every agent can read it fresh instead of relying on copy-pasted prompt fragments that drift.
+
+The bad version tells the reader what the article is about. The good version tells them the answer. They'll keep reading to see why.
+
+## Writing Explanatory Prose
+
+When you need to explain how something works between code blocks, show the mechanism. Don't describe it abstractly.
+
+Bad (abstract narration):
+
+> The system uses a layered approach to handle data storage efficiently. Each layer provides a different level of abstraction, allowing consumers to interact with data at the appropriate granularity for their use case.
+
+Good (shows the mechanism):
+
+> `RowStore` wraps `CellStore`, which wraps `YKeyValueLww`. Each layer adds one thing: `YKeyValueLww` handles conflict resolution, `CellStore` parses cell keys into row/column pairs, and `RowStore` maintains an in-memory index for O(1) lookups. The consumer only sees `RowStore`.
+
+The first version could describe anything. The second version could only describe this system.
+
+## Constraints
+
+Bullet lists and numbered lists: max 1-2 of each per article. If you need more, convert to prose or a table.
+
+Section headings: use sparingly. Not every paragraph needs a heading. Let content flow naturally between ideas using bridge sentences (see [writing-voice](../writing-voice/SKILL.md) "Connect ideas without headers").
+
+Bold text: avoid in body content. Use sparingly if needed for emphasis.
+
+No space-dash-space: use colons, semicolons, or em dashes per writing-voice.
+
+No rigid template: structure should fit the content, not the other way around. Some articles need a "Problem/Solution" flow; others just show code and explain. Don't force sections.
+
+## Articles Have Different Shapes
+
+Don't follow a single template. Structure should fit the content. Some common shapes:
+
+**Problem → fix** (short, practical): State the problem, show the code that fixes it, explain why. No diagrams, no tables, no extra sections. 30-50 lines.
+
+**Mechanism explainer** (medium): Explain how something works under the hood, alternating prose and code. Diagrams when the flow is non-obvious. 50-80 lines.
+
+**Comparison or tradeoff analysis** (longer): Show two or more approaches with real code from each. A table can help here because the comparison IS the point. ASCII diagrams when architecture differs between approaches. 80-150 lines.
+
+The shape emerges from the content. If you find yourself adding a diagram or table to fill a perceived gap, you don't need it.
+
+## What Makes Articles Good
+
+- Real code from real codebases, not abstract examples
+- Tight prose that explains WHY, not WHAT (code shows WHAT)
+- Prose and visuals alternate naturally; neither dominates for long stretches
+- Opening paragraph delivers the insight, not a topic announcement
+- Visual elements (diagrams, tables) only when they earn their place
+- Length matches content: 30-50 lines for focused fixes, 80-150 for comparisons
+
+## What Makes Articles Bad
+
+- Rigid section structure that doesn't fit the content
+- Multiple bullet lists and numbered lists throughout
+- Abstract `foo`/`bar` code examples
+- Over-explaining self-explanatory code
+- Bold formatting scattered through body text
+- Numbered bold headings for multi-part arguments (`**1. Bold heading**` pattern)
+- Summary tables tacked on at the end that restate what the prose already said
+- Marketing language or AI giveaways
+- More than 4-5 sentences of prose without a visual break
+- Opening that announces the topic instead of delivering the insight
+- Closing that reaches for a grand summary or call to action
+
+## Narrative Mode (Rare)
+
+Most "journey to an insight" articles still work better as punchy. Use narrative only when the discovery process itself is the insight and can't be compressed.
+
+When narrative fits: specific details ("750 lines", not "a large file"), direct statements over manufactured drama, build to an insight rather than starting with it.
+
+## Closings
+
+End with a plain statement of the implication. Don't reach for a grand summary or a clever sign-off. If the article showed that X solves Y, just say what that means for the reader in one or two sentences. Avoid closing with superlatives ("the most elegant", "truly powerful") or calls to action ("try it today!").

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -1,0 +1,423 @@
+---
+name: testing
+description: Test file conventions for setup functions, factory patterns, test organization, type testing, and naming. Use when writing or modifying *.test.ts files, creating test setup functions, or reviewing test structure.
+---
+
+# Test File Conventions
+
+## File-Level Doc Comments
+
+Every `.test.ts` file MUST start with a JSDoc block explaining what is being tested and the key behaviors verified. This serves as documentation for the module's contract.
+
+### Structure
+
+```typescript
+/**
+ * [Module Name] Tests
+ *
+ * [1-3 sentences explaining what this file tests and why these tests matter.]
+ *
+ * Key behaviors:
+ * - [Behavior 1]
+ * - [Behavior 2]
+ * - [Behavior 3]
+ *
+ * See also:
+ * - `related-file.test.ts` for [related aspect]
+ */
+```
+
+### Good Example
+
+```typescript
+/**
+ * Cell-Level LWW CRDT Sync Tests
+ *
+ * Verifies cell-level LWW conflict resolution where each field
+ * has its own timestamp. Unlike row-level LWW, concurrent edits to
+ * DIFFERENT fields merge independently.
+ *
+ * Key behaviors:
+ * - Concurrent edits to SAME field: latest timestamp wins
+ * - Concurrent edits to DIFFERENT fields: BOTH preserved (merge)
+ * - Delete removes all cells for a row
+ */
+```
+
+### Bad Example (Too Minimal)
+
+```typescript
+// Tests for create-tables
+```
+
+### Section Headers
+
+For long test files (100+ lines), use comment headers to separate logical sections:
+
+```typescript
+// ============================================================================
+// MESSAGE_SYNC Tests
+// ============================================================================
+```
+
+## Multi-Aspect Test File Splitting
+
+When a module has distinct behavioral aspects, split into focused test files rather than one monolithic file:
+
+| Pattern                       | Use Case                                             |
+| ----------------------------- | ---------------------------------------------------- |
+| `{module}.test.ts`            | Core CRUD behavior, happy paths, edge cases          |
+| `{module}.types.test.ts`      | Type inference verification, negative type tests     |
+| `{module}.{scenario}.test.ts` | Specific scenarios (CRDT sync, offline, integration) |
+
+### When to Split
+
+- File exceeds ~500 lines
+- Tests cover genuinely distinct concerns (CRUD vs sync vs types)
+- Different setup requirements per concern
+
+### When NOT to Split
+
+- Splitting would create files with fewer than 3 tests
+- All tests share the same setup and concern
+
+## Test Naming
+
+Test descriptions MUST be behavior assertions, not vague descriptions. The name should tell you what broke when the test fails.
+
+### Rules
+
+1. **State what happens**, not "should work" or "handles correctly"
+2. **Include the condition** when testing edge cases
+3. **No filler words**: "should", "correctly", "properly" add nothing
+
+### Good Names
+
+```typescript
+test('upsert stores row and get retrieves it', () => { ... });
+test('filter returns only published posts', () => { ... });
+test('concurrent edits to different fields: both preserved', () => { ... });
+test('delete vs update race: update wins (rightmost entry)', () => { ... });
+test('observer fires once per transaction, not per operation', () => { ... });
+test('get() throws for undefined tables with helpful message', () => { ... });
+```
+
+### Bad Names
+
+```typescript
+test('should work correctly', () => { ... });         // What works? What's correct?
+test('should handle batch operations', () => { ... }); // Handle how?
+test('basic test', () => { ... });                     // Says nothing
+test('should create and retrieve rows correctly', () => { ... }); // Vague "correctly"
+```
+
+### Pattern: `{action} {outcome} [condition]`
+
+```
+"upsert stores row and get retrieves it"
+ ^^^^^^ ^^^^^^^^^^   ^^^ ^^^^^^^^^^^^^
+ action  outcome    action  outcome
+
+"observer fires once per transaction, not per operation"
+ ^^^^^^^^ ^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ subject   outcome              condition
+
+"get() returns not_found for non-existent rows"
+ ^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^
+ action     outcome            condition
+```
+
+## Negative Type Tests
+
+For library code, test that incorrect types are rejected. Use `@ts-expect-error` to verify the compiler catches type errors.
+
+### When to Use
+
+- `.types.test.ts` files testing type inference
+- Any test verifying a public API's type constraints
+- Especially important for generic APIs where incorrect input should fail at compile time
+
+### Pattern
+
+```typescript
+test('rejects invalid row data at compile time', () => {
+	const doc = createTables(new Y.Doc(), [
+		table({
+			id: 'posts',
+			name: '',
+			fields: [id(), text({ id: 'title' })] as const,
+		}),
+	]);
+
+	// @ts-expect-error — missing required field 'title'
+	doc.get('posts').upsert({ id: Id('1') });
+
+	// @ts-expect-error — wrong type for 'title' (number instead of string)
+	doc.get('posts').upsert({ id: Id('1'), title: 42 });
+
+	// @ts-expect-error — unknown table name
+	doc.get('nonexistent');
+});
+```
+
+### Rules
+
+1. ALWAYS include a comment explaining what error is expected: `// @ts-expect-error — [reason]`
+2. One `@ts-expect-error` per assertion — don't stack them
+3. Group negative type tests in their own `describe('type errors', () => { ... })` block
+4. These tests verify the compiler catches errors — they don't need runtime assertions
+
+### In `bun:test` (No `expectTypeOf`)
+
+Since we use `bun:test` (not Vitest), we don't have `expectTypeOf`. Use these alternatives:
+
+- **Positive type tests**: Let TypeScript check the types — if it compiles, the types work. Add comments like `// Type: { id: string; title: string }` for documentation.
+- **Negative type tests**: `@ts-expect-error` to verify rejection
+- **CI enforcement**: `bun typecheck` (runs `tsc --noEmit`) catches type regressions
+
+## No `as any` in Tests
+
+Tests MUST NOT use `as any` to bypass type checking. Tests should prove the types work, not circumvent them.
+
+### Alternatives
+
+| Instead of                          | Use                                                                                                     |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `(obj as any).privateMethod()`      | Test through the public API                                                                             |
+| `tables.get('bad' as any)`          | Keep `as any` ONLY when testing runtime error handling for invalid input — add a comment explaining why |
+| `createMock() as any`               | Create a properly typed mock or use a minimal type                                                      |
+| `(content as any).store.ensure(id)` | Expose a test-only accessor or test through public API                                                  |
+
+### Acceptable `as any` (With Comment)
+
+```typescript
+// Testing runtime error for invalid table name — bypasses TypeScript intentionally
+expect(() => tables.get('nonexistent' as any)).toThrow(
+	/Table 'nonexistent' not found/,
+);
+```
+
+### Never Acceptable
+
+```typescript
+// Bad — hiding a real type problem
+const result = someFunction(data as any);
+expect(result).toBe('expected');
+```
+
+## The `setup()` Pattern
+
+Every test file that needs shared infrastructure MUST have a `setup()` function. This replaces `beforeEach` for code reuse, following Kent C. Dodds' principle: "We have functions for that."
+
+### Rules
+
+1. `setup()` ALWAYS returns a destructured object, even for single values
+2. Tests ALWAYS destructure the return: `const { thing } = setup()`
+3. `setup()` is a plain function, not a hook — each test calls it independently
+4. No mutable `let` variables at describe scope — setup returns fresh state per test
+
+### Why Always an Object (Even for One Value)
+
+- **Extensibility**: Adding a second value later doesn't require changing any existing callsites
+- **Self-documenting**: `const { files } = setup()` tells you what you're getting by name
+- **Consistency**: Every test file follows the same pattern — no guessing
+
+### Single Value
+
+```typescript
+// Good — always an object, even for one thing
+function setup() {
+	const ws = createWorkspace({ id: 'test', tables: { files: filesTable } });
+	return { files: ws.tables.files };
+}
+
+test('creates a file', () => {
+	const { files } = setup();
+	files.set({ id: '1', name: 'test.txt', _v: 1 });
+	expect(files.has('1')).toBe(true);
+});
+```
+
+```typescript
+// Bad — returns value directly
+function setup() {
+	const ws = createWorkspace({ id: 'test', tables: { files: filesTable } });
+	return ws.tables.files; // No destructuring = breaks convention
+}
+```
+
+### Multiple Values
+
+```typescript
+function setup() {
+	const ydoc = new Y.Doc();
+	const yarray = ydoc.getArray<YKeyValueLwwEntry<unknown>>('test-table');
+	const ykv = new YKeyValueLww(yarray);
+	return { ydoc, yarray, ykv };
+}
+
+test('stores a row', () => {
+	const { ykv } = setup(); // Take only what you need
+	// ...
+});
+
+test('atomic transactions', () => {
+	const { ydoc, ykv } = setup(); // Take multiple when needed
+	ydoc.transact(() => {
+		ykv.set('1', { name: 'Alice' });
+	});
+});
+```
+
+### Composable Setup Functions
+
+When tests need additional setup beyond the base, create composable setup variants that build on `setup()`:
+
+```typescript
+function setup() {
+	const tableDef = defineTable(fileSchema);
+	const ydoc = new Y.Doc({ guid: 'test-workspace' });
+	const tables = createTables(ydoc, { files: tableDef });
+	return { ydoc, tables };
+}
+
+function setupWithBinding(
+	overrides?: Partial<Parameters<typeof createDocumentBinding>[0]>,
+) {
+	const { ydoc, tables } = setup();
+	const binding = createDocumentBinding({
+		guidKey: 'id',
+		tableHelper: tables.files,
+		ydoc,
+		...overrides,
+	});
+	return { ydoc, tables, binding };
+}
+```
+
+### When `setup()` Is NOT Needed
+
+- Pure function tests with no shared infrastructure (e.g., `parseFrontmatter('# Hello')`)
+- Tests where each case has completely different inputs with no overlap
+- Type-only test files (`*.test-d.ts`)
+
+## Avoid `beforeEach` for Setup
+
+Use `beforeEach`/`afterEach` ONLY for cleanup that must run even if a test fails (server shutdown, spy restoration). Never use them for data setup.
+
+```typescript
+// Bad — mutable state, hidden setup
+let files: TableHelper;
+beforeEach(() => {
+	const ws = createWorkspace({ id: 'test', tables: { files: filesTable } });
+	files = ws.tables.files;
+});
+
+// Good — setup function, immutable per-test
+function setup() {
+	const ws = createWorkspace({ id: 'test', tables: { files: filesTable } });
+	return { files: ws.tables.files };
+}
+```
+
+## Shared Schemas at Module Level
+
+Schemas and table definitions used across multiple tests should be defined at module level, outside `setup()`:
+
+```typescript
+const fileSchema = type({
+	id: 'string',
+	name: 'string',
+	updatedAt: 'number',
+	_v: '1',
+});
+
+const filesTable = defineTable(fileSchema);
+
+function setup() {
+	const ws = createWorkspace({ id: 'test', tables: { files: filesTable } });
+	return { files: ws.tables.files };
+}
+```
+
+These are stateless definitions — safe to share. Stateful objects (Y.Doc, workspace instances) go in `setup()`.
+
+## Don't Return Dead Weight
+
+Every property in the setup return should be used by at least one test. If no test uses `ydoc`, don't return it:
+
+```typescript
+// Bad — ydoc is never destructured by any test
+function setup() {
+	const ydoc = new Y.Doc();
+	return { ydoc, tl: createTimeline(ydoc) };
+}
+
+// Good — only return what tests actually use
+function setup() {
+	return { tl: createTimeline(new Y.Doc()) };
+}
+```
+
+Exception: if a value is needed for cleanup or might be needed by future tests in the same file, keeping it is fine.
+
+## Test Structure
+
+### Flat Over Nested
+
+Prefer flat `test()` calls. Use `describe()` only to group genuinely distinct behavioral categories of the same unit:
+
+```typescript
+// Good — describe groups behaviors, tests are flat within
+describe('FileTree', () => {
+	describe('create', () => {
+		test('creates file at root', () => { ... });
+		test('rejects invalid names', () => { ... });
+	});
+
+	describe('move', () => {
+		test('renames file', () => { ... });
+		test('moves to different parent', () => { ... });
+	});
+});
+```
+
+```typescript
+// Bad — unnecessary nesting
+describe('FileTree', () => {
+	describe('create', () => {
+		describe('when the name is valid', () => {
+			describe('and the parent exists', () => {
+				test('creates the file', () => { ... });
+			});
+		});
+	});
+});
+```
+
+### Helper Functions Over Nesting
+
+When tests need different setup scenarios, use named setup variants (not nested `describe` + `beforeEach`):
+
+```typescript
+// Good — composable setup functions
+function setupWithFiles() {
+	const { files } = setup();
+	files.set(makeRow('f1', 'test.txt'));
+	files.set(makeRow('f2', 'other.txt'));
+	return { files };
+}
+
+test('lists all files', () => {
+	const { files } = setupWithFiles();
+	expect(files.count()).toBe(2);
+});
+```
+
+## References
+
+- Kent C. Dodds, ["Avoid Nesting When You're Testing"](https://kentcdodds.com/blog/avoid-nesting-when-youre-testing) — setup functions over beforeEach, flat tests
+- Kent C. Dodds, ["AHA Testing"](https://kentcdodds.com/blog/aha-testing) — avoid hasty abstractions in tests
+- Kent C. Dodds, [Testing JavaScript](https://testingjavascript.com) — Test Object Factory Pattern
+- Matt Pocock, ["How to test your types"](https://www.totaltypescript.com/how-to-test-your-types) — vitest `expectTypeOf` for type testing
+- Matt Pocock, [`shoehorn`](https://github.com/total-typescript/shoehorn) — partial mocks for test ergonomics

--- a/.claude/skills/typescript/SKILL.md
+++ b/.claude/skills/typescript/SKILL.md
@@ -1,0 +1,798 @@
+---
+name: typescript
+description: TypeScript code style, type co-location, naming conventions (including acronym casing), test organization, and arktype patterns. Use when writing TypeScript code, defining types, naming variables/functions, organizing tests, or working with arktype schemas.
+---
+
+# TypeScript Guidelines
+
+## Core Rules
+
+- Always use `type` instead of `interface` in TypeScript.
+- **`readonly` only for arrays and maps**: Never use `readonly` on primitive properties or object properties. The modifier is shallow and provides little protection for non-collection types. Use it only where mutation is a realistic footgun:
+
+  ```typescript
+  // Good - readonly only on the array
+  type Config = {
+  	version: number;
+  	vendor: string;
+  	items: readonly string[];
+  };
+
+  // Bad - readonly everywhere is noise
+  type Config = {
+  	readonly version: number;
+  	readonly vendor: string;
+  	readonly items: readonly string[];
+  };
+  ```
+
+  Exception: Match upstream library types exactly (e.g., standard-schema interfaces). See `docs/articles/readonly-is-mostly-noise.md` for rationale.
+
+- **Acronyms in camelCase**: Treat acronyms as single words, capitalizing only the first letter:
+
+  ```typescript
+  // Correct - acronyms as words
+  parseUrl();
+  defineKv();
+  readJson();
+  customerId;
+  httpClient;
+
+  // Incorrect - all-caps acronyms
+  parseURL();
+  defineKV();
+  readJSON();
+  customerID;
+  HTTPClient;
+  ```
+
+  Exception: Match existing platform APIs (e.g., `XMLHttpRequest`). See `docs/articles/acronyms-in-camelcase.md` for rationale.
+
+- TypeScript 5.5+ automatically infers type predicates in `.filter()` callbacks. Don't add manual type assertions:
+
+  ```typescript
+  // Good - TypeScript infers the narrowed type automatically
+  const filtered = items.filter((x) => x !== undefined);
+
+  // Bad - unnecessary type predicate
+  const filtered = items.filter(
+  	(x): x is NonNullable<typeof x> => x !== undefined,
+  );
+  ```
+
+- When moving components to new locations, always update relative imports to absolute imports (e.g., change `import Component from '../Component.svelte'` to `import Component from '$lib/components/Component.svelte'`)
+- When functions are only used in the return statement of a factory/creator function, use object method shorthand syntax instead of defining them separately. For example, instead of:
+  ```typescript
+  function myFunction() {
+  	const helper = () => {
+  		/* ... */
+  	};
+  	return { helper };
+  }
+  ```
+  Use:
+  ```typescript
+  function myFunction() {
+  	return {
+  		helper() {
+  			/* ... */
+  		},
+  	};
+  }
+  ```
+- **Prefer factory functions over classes**: Use `function createX() { return { ... } }` instead of `class X { ... }`. Closures provide structural privacy—everything above the return statement is private by position, everything inside it is the public API. Classes mix `private`/`protected`/public members in arbitrary order, forcing you to scan every member and check its modifier. See `docs/articles/closures-are-better-privacy-than-keywords.md` for rationale.
+
+
+## Switch Over If/Else for Value Comparison
+
+When multiple `if`/`else if` branches compare the same variable against string literals (or other constant values), always use a `switch` statement instead. This applies to action types, status fields, file types, strategy names, or any discriminated value.
+
+```typescript
+// Bad - if/else chain comparing the same variable
+if (change.action === 'add') {
+	handleAdd(change);
+} else if (change.action === 'update') {
+	handleUpdate(change);
+} else if (change.action === 'delete') {
+	handleDelete(change);
+}
+
+// Good - switch statement
+switch (change.action) {
+	case 'add':
+		handleAdd(change);
+		break;
+	case 'update':
+		handleUpdate(change);
+		break;
+	case 'delete':
+		handleDelete(change);
+		break;
+}
+```
+
+Use fall-through for cases that share logic:
+
+```typescript
+switch (change.action) {
+	case 'add':
+	case 'update': {
+		applyChange(change);
+		break;
+	}
+	case 'delete': {
+		removeChange(change);
+		break;
+	}
+}
+```
+
+Use block scoping (`{ }`) when a case declares variables with `let` or `const`.
+
+When NOT to use switch: early returns for type narrowing are fine as sequential `if` statements. If each branch returns immediately and the checks are narrowing a union type for subsequent code, keep them as `if` guards.
+
+See `docs/articles/switch-over-if-else-for-value-comparison.md` for rationale.
+
+## Record Lookup Over Nested Ternaries
+
+When an expression maps a finite set of known values to outputs, use a `satisfies Record` lookup instead of nested ternaries. This is the expression-level counterpart to "Switch Over If/Else": switch handles statements with side effects, record lookup handles value mappings.
+
+```typescript
+// Bad - nested ternary
+const tooltip = status === 'connected'
+	? 'Connected'
+	: status === 'connecting'
+		? 'Connecting…'
+		: 'Offline';
+
+// Good - record lookup with exhaustive type checking
+const tooltip = ({
+	connected: 'Connected',
+	connecting: 'Connecting…',
+	offline: 'Offline',
+} satisfies Record<SyncStatus, string>)[status];
+```
+
+`satisfies Record<SyncStatus, string>` gives you compile-time exhaustiveness: if `SyncStatus` gains a fourth value, TypeScript errors because the record is missing a key. Nested ternaries silently fall through to the else branch.
+
+`as const` is unnecessary here. `satisfies` already validates the shape and value types. `as const` would narrow values to literal types (`'Connected'` instead of `string`), which adds no value when the output is just rendered or passed as a string.
+
+When the record is used once, inline it. When it's shared or has 5+ entries, extract to a named constant.
+
+See `docs/articles/record-lookup-over-nested-ternaries.md` for rationale.
+
+# Type Co-location Principles
+
+## Never Use Generic Type Buckets
+
+Don't create generic type files like `$lib/types/models.ts`. This creates unclear dependencies and makes code harder to maintain.
+
+### Bad Pattern
+
+```typescript
+// $lib/types/models.ts - Generic bucket for unrelated types
+export type LocalModelConfig = { ... };
+export type UserModel = { ... };
+export type SessionModel = { ... };
+```
+
+### Good Pattern
+
+```typescript
+// $lib/services/transcription/local/types.ts - Co-located with service
+export type LocalModelConfig = { ... };
+
+// $lib/services/user/types.ts - Co-located with user service
+export type UserModel = { ... };
+```
+
+## Co-location Rules
+
+1. **Service-specific types**: Place in `[service-folder]/types.ts`
+2. **Component-specific types**: Define directly in the component file
+3. **Shared domain types**: Place in the domain folder's `types.ts`
+4. **Cross-domain types**: Only if truly shared across multiple domains, place in `$lib/types/[specific-name].ts`
+
+## `types.ts` Is A Code Smell (Prefer Computed Types Over Manual Declarations)
+
+When a type can be derived from a runtime value, derive it. Don't declare it manually in a separate file.
+
+```typescript
+// Good — type is computed from the runtime definition
+export const BROWSER_TABLES = { devices, tabs, windows };
+export type Tab = InferTableRow<typeof BROWSER_TABLES.tabs>;
+
+// Good — type is derived from schema
+const userSchema = z.object({ id: z.string(), email: z.string() });
+type User = z.infer<typeof userSchema>;
+
+// Bad — manually declaring what already exists as a runtime value
+// types.ts
+export type Tab = { id: string; deviceId: string /* ... */ };
+```
+
+If every type in a `types.ts` can be derived with `typeof`, `z.infer`, `InferTableRow`, `ReturnType`, etc., the file is redundant. Put each type next to the runtime value it's computed from.
+
+# Constant Array Naming Conventions
+
+## Pattern Summary
+
+| Pattern                         | Suffix                 | Description             | Example                                  |
+| ------------------------------- | ---------------------- | ----------------------- | ---------------------------------------- |
+| Simple values (source of truth) | Plural noun with unit  | Raw values array        | `BITRATES_KBPS`, `SAMPLE_RATES`          |
+| Rich array (source of truth)    | Plural noun            | Contains all metadata   | `PROVIDERS`, `RECORDING_MODE_OPTIONS`    |
+| IDs only (for validation)       | `_IDS`                 | Derived from rich array | `PROVIDER_IDS`                           |
+| UI options `{value, label}`     | `_OPTIONS`             | For dropdowns/selects   | `BITRATE_OPTIONS`, `SAMPLE_RATE_OPTIONS` |
+| Label map                       | `_TO_LABEL` (singular) | `Record<Id, string>`    | `LANGUAGES_TO_LABEL`                     |
+
+## When to Use Each Pattern
+
+### Pattern 1: Simple Values -> Derived Options
+
+Use when the label can be computed from the value:
+
+```typescript
+// constants/audio/bitrate.ts
+export const BITRATES_KBPS = ['16', '32', '64', '128'] as const;
+
+export const BITRATE_OPTIONS = BITRATES_KBPS.map((bitrate) => ({
+	value: bitrate,
+	label: `${bitrate} kbps`,
+}));
+```
+
+### Pattern 2: Simple Values + Metadata Object
+
+Use when labels need richer information than the value alone:
+
+```typescript
+// constants/audio/sample-rate.ts
+export const SAMPLE_RATES = ['16000', '44100', '48000'] as const;
+
+const SAMPLE_RATE_METADATA: Record<
+	SampleRate,
+	{ shortLabel: string; description: string }
+> = {
+	'16000': { shortLabel: '16 kHz', description: 'Optimized for speech' },
+	'44100': { shortLabel: '44.1 kHz', description: 'CD quality' },
+	'48000': { shortLabel: '48 kHz', description: 'Studio quality' },
+};
+
+export const SAMPLE_RATE_OPTIONS = SAMPLE_RATES.map((rate) => ({
+	value: rate,
+	label: `${SAMPLE_RATE_METADATA[rate].shortLabel} - ${SAMPLE_RATE_METADATA[rate].description}`,
+}));
+```
+
+### Pattern 3: Rich Array as Source of Truth
+
+Use when options have extra fields beyond `value`/`label` (e.g., `icon`, `desktopOnly`):
+
+```typescript
+// constants/audio/recording-modes.ts
+export const RECORDING_MODES = ['manual', 'vad', 'upload'] as const;
+export type RecordingMode = (typeof RECORDING_MODES)[number];
+
+export const RECORDING_MODE_OPTIONS = [
+	{ label: 'Manual', value: 'manual', icon: 'mic', desktopOnly: false },
+	{
+		label: 'Voice Activated',
+		value: 'vad',
+		icon: 'mic-voice',
+		desktopOnly: false,
+	},
+	{ label: 'Upload File', value: 'upload', icon: 'upload', desktopOnly: false },
+] as const satisfies {
+	label: string;
+	value: RecordingMode;
+	icon: string;
+	desktopOnly: boolean;
+}[];
+
+// Derive IDs for validation if needed
+export const RECORDING_MODE_IDS = RECORDING_MODE_OPTIONS.map((o) => o.value);
+```
+
+## Choosing a Pattern
+
+| Scenario                                                          | Pattern                  |
+| ----------------------------------------------------------------- | ------------------------ |
+| Label = formatted value (e.g., "128 kbps")                        | Simple Values -> Derived |
+| Label needs separate data (e.g., "16 kHz - Optimized for speech") | Values + Metadata        |
+| Options have extra UI fields (icon, description, disabled)        | Rich Array               |
+| Platform-specific or runtime-conditional content                  | Keep inline in component |
+
+## Naming Rules
+
+### Source Arrays
+
+- Use **plural noun**: `PROVIDERS`, `MODES`, `LANGUAGES`
+- Add unit suffix when relevant: `BITRATES_KBPS`, `SAMPLE_RATES`
+- Avoid redundant `_VALUES` suffix
+
+### Derived/Options Arrays
+
+- Use **plural noun** + `_OPTIONS` suffix: `BITRATE_OPTIONS`, `SAMPLE_RATE_OPTIONS`
+- For IDs: **plural noun** + `_IDS` suffix: `PROVIDER_IDS`
+
+### Label Maps
+
+- Use **singular** `_TO_LABEL` suffix: `LANGUAGES_TO_LABEL`
+- Describes the operation (id -> label), not the container
+- Reads naturally: `LANGUAGES_TO_LABEL[lang]` = "get the label for this language"
+
+### Constant Casing
+
+- Always use `SCREAMING_SNAKE_CASE` for exported constants
+- Never use `camelCase` for constant objects/arrays
+
+## Co-location
+
+Options arrays should be co-located with their source array in the same file. Avoid creating options inline in Svelte components; import pre-defined options instead.
+
+Exception: Keep options inline when they have platform-specific or runtime-conditional content that would require importing platform constants into the data module.
+
+# Parameter Destructuring for Factory Functions
+
+## Prefer Parameter Destructuring Over Body Destructuring
+
+When writing factory functions that take options objects, destructure directly in the function signature instead of in the function body. This is the established pattern in the codebase.
+
+### Bad Pattern (Body Destructuring)
+
+```typescript
+// DON'T: Extra line of ceremony
+function createSomething(opts: { foo: string; bar?: number }) {
+	const { foo, bar = 10 } = opts; // Unnecessary extra line
+	return { foo, bar };
+}
+```
+
+### Good Pattern (Parameter Destructuring)
+
+```typescript
+// DO: Destructure directly in parameters
+function createSomething({ foo, bar = 10 }: { foo: string; bar?: number }) {
+	return { foo, bar };
+}
+```
+
+### Why This Matters
+
+1. **Fewer lines**: Removes the extra destructuring statement
+2. **Defaults at API boundary**: Users see defaults in the signature, not hidden in the body
+3. **Works with `const` generics**: TypeScript literal inference works correctly:
+   ```typescript
+   function select<const TOptions extends readonly string[]>({
+     options,
+     nullable = false,
+   }: {
+     options: TOptions;
+     nullable?: boolean;
+   }) { ... }
+   ```
+4. **Closures work identically**: Inner functions capture the same variables either way
+
+### When Body Destructuring is Valid
+
+- Need to distinguish "property missing" vs "property is `undefined`" (`'key' in opts`)
+- Complex normalization/validation of the options object
+- Need to pass the entire `opts` object to other functions
+
+### Codebase Examples
+
+```typescript
+// From packages/epicenter/src/core/schema/columns.ts
+export function select<const TOptions extends readonly [string, ...string[]]>({
+  options,
+  nullable = false,
+  default: defaultValue,
+}: {
+  options: TOptions;
+  nullable?: boolean;
+  default?: TOptions[number];
+}): SelectColumnSchema<TOptions, boolean> {
+  return { type: 'select', nullable, options, default: defaultValue };
+}
+
+// From apps/whispering/.../create-key-recorder.svelte.ts
+export function createKeyRecorder({
+  pressedKeys,
+  onRegister,
+  onClear,
+}: {
+  pressedKeys: PressedKeys;
+  onRegister: (keyCombination: KeyboardEventSupportedKey[]) => void;
+  onClear: () => void;
+}) { ... }
+```
+
+# Arktype Optional Properties
+
+## Never Use `| undefined` for Optional Properties
+
+When defining optional properties in arktype schemas, always use the `'key?'` syntax instead of `| undefined` unions. This is critical for JSON Schema conversion (used by OpenAPI/MCP).
+
+### Bad Pattern
+
+```typescript
+// DON'T: Explicit undefined union - breaks JSON Schema conversion
+const schema = type({
+	window_id: 'string | undefined',
+	url: 'string | undefined',
+});
+```
+
+This produces invalid JSON Schema with `anyOf: [{type: "string"}, {}]` because `undefined` has no JSON Schema equivalent.
+
+### Good Pattern
+
+```typescript
+// DO: Optional property syntax - converts cleanly to JSON Schema
+const schema = type({
+	'window_id?': 'string',
+	'url?': 'string',
+});
+```
+
+This correctly omits properties from the `required` array in JSON Schema.
+
+### Why This Matters
+
+| Syntax                       | TypeScript Behavior                        | JSON Schema                     |
+| ---------------------------- | ------------------------------------------ | ------------------------------- |
+| `key: 'string \| undefined'` | Required prop, accepts string or undefined | Broken (triggers fallback)      |
+| `'key?': 'string'`           | Optional prop, accepts string              | Clean (omitted from `required`) |
+
+Both behave similarly in TypeScript, but only the `?` syntax converts correctly to JSON Schema for OpenAPI documentation and MCP tool schemas.
+
+# Inline Definitions in Tests
+
+## Prefer Inlining Single-Use Definitions
+
+When a schema, builder, or configuration is only used once in a test, inline it directly at the call site rather than extracting to a variable.
+
+### Bad Pattern (Extracted Variables)
+
+```typescript
+test('creates workspace with tables', () => {
+	const posts = defineTable(type({ id: 'string', title: 'string', _v: '1' }));
+
+	const theme = defineKv(type({ mode: "'light' | 'dark'", _v: '1' }));
+
+	const workspace = defineWorkspace({
+		id: 'test-app',
+		tables: { posts },
+		kv: { theme },
+	});
+
+	expect(workspace.id).toBe('test-app');
+});
+```
+
+### Good Pattern (Inlined)
+
+```typescript
+test('creates workspace with tables', () => {
+	const workspace = defineWorkspace({
+		id: 'test-app',
+		tables: {
+			posts: defineTable(type({ id: 'string', title: 'string', _v: '1' })),
+		},
+		kv: {
+			theme: defineKv(type({ mode: "'light' | 'dark'", _v: '1' })),
+		},
+	});
+
+	expect(workspace.id).toBe('test-app');
+});
+```
+
+### Why Inlining is Better
+
+1. **All context in one place**: No scrolling to understand what `posts` or `theme` are
+2. **Reduces naming overhead**: No need to invent variable names for single-use values
+3. **Matches mental model**: The definition IS the usage - they're one conceptual unit
+4. **Easier to copy/modify**: Self-contained test setup is easier to duplicate and tweak
+
+### When to Extract
+
+Extract to a variable when:
+
+- The value is used **multiple times** in the same test
+- You need to call **methods on the result** (e.g., `posts.migrate()`, `posts.versions`)
+- The definition is **shared across multiple tests** in a `beforeEach` or test fixture
+- The inline version would exceed ~15-20 lines and hurt readability
+
+### Applies To
+
+- `defineTable()`, `defineKv()`, `defineWorkspace()` builders
+- `createTables()`, `createKV()` factory calls
+- Schema definitions (arktype, zod, etc.)
+- Configuration objects passed to factories
+- Mock functions used only once
+
+# Test File Organization
+
+## Shadow Source Files with Test Files
+
+Each source file should have a corresponding test file in the same directory:
+
+```
+src/static/
+├── schema-union.ts
+├── schema-union.test.ts      # Tests for schema-union.ts
+├── define-table.ts
+├── define-table.test.ts      # Tests for define-table.ts
+├── create-tables.ts
+├── create-tables.test.ts     # Tests for create-tables.ts
+└── types.ts                  # No test file (pure types)
+```
+
+### Benefits
+
+- **Clear ownership**: Each test file tests exactly one source file
+- **Easy navigation**: Find tests by looking next to the source
+- **Focused testing**: Easier to run tests for just one module
+- **Maintainability**: When source changes, you know which test file to update
+
+### What Gets Test Files
+
+| File Type                      | Test File? | Reason                                |
+| ------------------------------ | ---------- | ------------------------------------- |
+| Functions/classes with logic   | Yes        | Has behavior to test                  |
+| Type definitions only          | No         | No runtime behavior                   |
+| Re-export barrels (`index.ts`) | No         | Just re-exports, tested via consumers |
+| Internal helpers               | Maybe      | Test via consumer if tightly coupled  |
+
+### Naming Convention
+
+- Source: `foo-bar.ts`
+- Test: `foo-bar.test.ts`
+
+### Integration Tests
+
+For tests spanning multiple modules, either:
+
+- Add to the test file of the highest-level consumer
+- Create a dedicated `[feature].integration.test.ts` if substantial
+
+# Branded Types Pattern
+
+## Use Brand Constructors, Never Raw Type Assertions
+
+When working with branded types (nominal typing), always create a brand constructor function. Never use `as BrandedType` assertions scattered throughout the codebase.
+
+### Bad Pattern (Scattered Assertions)
+
+```typescript
+// types.ts
+type RowId = string & Brand<'RowId'>;
+
+// file1.ts
+const id = someString as RowId; // Bad: assertion here
+
+// file2.ts
+function getRow(id: string) {
+	doSomething(id as RowId); // Bad: another assertion
+}
+
+// file3.ts
+const parsed = key.split(':')[0] as RowId; // Bad: assertions everywhere
+```
+
+### Good Pattern (Brand Constructor)
+
+```typescript
+// types.ts
+import type { Brand } from 'wellcrafted/brand';
+
+type RowId = string & Brand<'RowId'>;
+
+// Brand constructor - THE ONLY place with `as RowId`
+// Uses PascalCase to match the type name (avoids parameter shadowing)
+function RowId(id: string): RowId {
+	return id as RowId;
+}
+
+// file1.ts
+const id = RowId(someString); // Good: uses constructor
+
+// file2.ts
+function getRow(rowId: string) {
+	doSomething(RowId(rowId)); // Good: no shadowing issues
+}
+
+// file3.ts
+const parsed = RowId(key.split(':')[0]); // Good: consistent
+```
+
+### Why Brand Constructors Are Better
+
+1. **Single source of truth**: Only one place has the type assertion
+2. **Future validation**: Easy to add runtime validation later
+3. **Searchable**: `RowId(` is easy to find and audit
+4. **Explicit boundaries**: Clear where unbranded -> branded conversion happens
+5. **Refactor-safe**: Change the branding logic in one place
+6. **No shadowing**: PascalCase constructor doesn't shadow camelCase parameters
+
+### Implementation Pattern
+
+```typescript
+import type { Brand } from 'wellcrafted/brand';
+
+// 1. Define the branded type
+export type RowId = string & Brand<'RowId'>;
+
+// 2. Create the brand constructor (only `as` assertion in codebase)
+// PascalCase matches the type - TypeScript allows same-name type + value
+export function RowId(id: string): RowId {
+	return id as RowId;
+}
+
+// 3. Optionally add validation
+export function RowId(id: string): RowId {
+	if (id.includes(':')) {
+		throw new Error(`RowId cannot contain ':': ${id}`);
+	}
+	return id as RowId;
+}
+```
+
+### Naming Convention
+
+| Branded Type   | Constructor Function |
+| -------------- | -------------------- |
+| `RowId`        | `RowId()`            |
+| `FieldId`      | `FieldId()`          |
+| `UserId`       | `UserId()`           |
+| `DocumentGuid` | `DocumentGuid()`     |
+
+The constructor uses **PascalCase matching the type name**. TypeScript allows a type and value to share the same name (different namespaces). This avoids parameter shadowing issues.
+
+### When Functions Accept Branded Types
+
+If a function requires a branded type, callers must use the brand constructor:
+
+```typescript
+// Function requires branded RowId
+function getRow(id: RowId): Row { ... }
+
+// Caller must brand the string - no shadowing since RowId() is PascalCase
+function processRow(rowId: string) {
+  getRow(RowId(rowId));  // rowId param doesn't shadow RowId() function
+}
+```
+
+This makes type boundaries visible and intentional, without forcing awkward parameter renames.
+
+### Branded IDs for Workspace Tables
+
+Every `defineTable()` schema MUST use branded ID types for the `id` field and all string foreign keys. Never use plain `'string'` for table IDs.
+
+For tables that use arktype schemas, define the brand as a type + arktype pipe pair:
+
+```typescript
+export type ConversationId = string & Brand<'ConversationId'>;
+export const ConversationId = type('string').pipe(
+	(s): ConversationId => s as ConversationId,
+);
+```
+
+Then use directly in the schema: `id: ConversationId` and for optional FKs: `'parentId?': ConversationId.or('undefined')`.
+
+When generating IDs with `generateId()` (which returns `Id`, a different brand), cast through string: `generateId() as string as ConversationId`.
+
+See the `static-workspace-api` skill for the full pattern and rules.
+
+# Extract Coupled `let` State Into Sub-Factories
+
+When a factory function accumulates `let` statements that are always read, written, and reset together, extract them into a sub-factory. The tell: two or three `let` declarations that move as a pack across multiple inner functions.
+
+## The Smell
+
+```typescript
+function createProvider(config) {
+  let retries = 0;
+  let reconnectSleeper: Sleeper | null = null;
+
+  async function runLoop() {
+    // ... 5-line backoff ceremony using retries + reconnectSleeper ...
+    // ... appears in TWO places ...
+  }
+
+  function handleOnline() {
+    reconnectSleeper?.wake(); // reaches into closure state
+  }
+
+  function handleSuccess() {
+    retries = 0; // reset scattered across the function
+  }
+}
+```
+
+`retries` and `reconnectSleeper` are one concept ("backoff") split across two `let` declarations, two inline ceremonies, and one external poke.
+
+## The Fix
+
+Pull coupled state into its own factory with named methods:
+
+```typescript
+function createBackoff() {
+  let retries = 0;
+  let sleeper: { promise: Promise<void>; wake(): void } | null = null;
+
+  return {
+    async sleep() { /* compute delay, create sleeper, await, cleanup */ },
+    wake() { sleeper?.wake(); },
+    reset() { retries = 0; },
+  };
+}
+```
+
+The parent factory replaces scattered `let` manipulation with named calls:
+
+```typescript
+function createProvider(config) {
+  const backoff = createBackoff();
+
+  async function runLoop() {
+    await backoff.sleep();     // was 5 duplicated lines
+  }
+
+  function handleOnline() {
+    backoff.wake();            // was reconnectSleeper?.wake()
+  }
+
+  function handleSuccess() {
+    backoff.reset();           // was retries = 0
+  }
+}
+```
+
+## When to Extract
+
+| Signal | Action |
+|---|---|
+| Two+ `let`s always set in the same function | Likely one concept |
+| Resetting one requires resetting the others | Definitely one concept |
+| An external caller reaches into one of them | The concept needs a public API |
+| The same multi-line ceremony appears twice | Extract and name it |
+
+## When NOT to Extract
+
+Don't extract `let` state that's deeply woven into control flow branching. If the variables are the loop's decision-making state (e.g., `desired`, `runId`, `connectRun` in a supervisor loop), extracting them just renames the complexity without reducing it. The test: do the call sites get simpler?
+
+See `docs/articles/let-packs-are-factories-waiting-to-be-named.md` for a full walkthrough with three extractions from a real sync provider.
+
+# Const Generic Array Inference
+
+Use `const T extends readonly T[]` to preserve literal types without requiring `as const` at call sites.
+
+| Pattern                             | Plain `['a','b','c']`      | With `as const`            |
+| ----------------------------------- | -------------------------- | -------------------------- |
+| `T extends string[]`                | `string[]`                 | `["a", "b", "c"]`          |
+| `T extends readonly string[]`       | `string[]`                 | `readonly ["a", "b", "c"]` |
+| `const T extends string[]`          | `["a", "b", "c"]`          | `["a", "b", "c"]`          |
+| `const T extends readonly string[]` | `readonly ["a", "b", "c"]` | `readonly ["a", "b", "c"]` |
+
+The `const` modifier preserves literal types; the `readonly` constraint determines mutability.
+
+```typescript
+// From packages/epicenter/src/core/schema/fields/factories.ts
+export function select<const TOptions extends readonly [string, ...string[]]>({
+	id,
+	options,
+}: {
+	id: string;
+	options: TOptions;
+}): SelectField<TOptions> {
+	// ...
+}
+
+// Caller gets literal union type — no `as const` needed
+const status = select({ id: 'status', options: ['draft', 'published'] });
+// status.options[number] is "draft" | "published", not string
+```
+
+See `docs/articles/typescript-const-modifier-generic-type-parameters.md` for details.

--- a/.claude/skills/workflow/SKILL.md
+++ b/.claude/skills/workflow/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: workflow
+description: Standard workflow for implementing features with specs and planning documents. Use when starting a new feature, planning implementation, or working on any non-trivial task.
+---
+
+# Standard Workflow
+
+1. First think through the problem, read the codebase for relevant files, and write a plan to specs/[timestamp] [feature-name].md where [timestamp] is the timestamp in YYYYMMDDThhmmss format and [feature-name] is the name of the feature.
+2. The plan should have a list of todo items that you can check off as you complete them
+3. Before you begin working, check in with me and I will verify the plan.
+4. Then, begin working on the todo items, marking them as complete as you go.
+5. Please every step of the way just give me a high level explanation of what changes you made
+6. Make every task and code change you do as simple as possible. We want to avoid making any massive or complex changes. Every change should impact as little code as possible. Everything is about simplicity.
+7. Finally, add a review section to the .md file with a summary of the changes you made and any other relevant information.
+
+# Spec Placement
+
+All specs live in the root `/specs/` directory. Do not create nested specs in `apps/` or `packages/`.

--- a/.claude/skills/writing-voice/SKILL.md
+++ b/.claude/skills/writing-voice/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: writing-voice
+description: Voice and tone rules for all written content—prose, UI text, tooltips, error messages. Use when writing any user-facing text.
+---
+
+# Writing Voice
+
+**Core principle**: Write for the ear, not just the eyes. Prose should be suitable to read out loud.
+
+## The Test
+
+Read it out loud. If it:
+
+- Sounds like a press release → rewrite
+- Sounds like a corporate memo → rewrite
+- Sounds stilted or unnatural → rewrite
+- Sounds like you explaining to a colleague → ship it
+
+## AI Dead Giveaways
+
+Patterns that scream "AI wrote this":
+
+- **Bold formatting everywhere**: Never bold section headers in body content
+- **Bullet list everything**: Convert to flowing paragraphs when possible
+- **Marketing words**: "game-changing", "revolutionary", "unleash", "empower"
+- **Structured sections**: "Key Features:", "Benefits:", "Why This Matters:"
+- **Vague superlatives**: "incredibly powerful", "seamlessly integrates"
+- **Dramatic hyperbole**: "feels like an eternity", "pain point", "excruciating"—use facts instead
+- **AI adjectives**: "perfectly", "effortlessly", "beautifully"
+- **Space-hyphen-space**: "The code works - the tests pass"
+- **Overusing fragments**: "Every. Single. Time." (once is emphasis, twice is a pattern)
+- **Staccato buildup**: Setup. Fragment. Fragment. Fragment. Punchline. This "dramatic reveal" pattern feels manufactured. Combine into one flowing sentence with em dashes or semicolons instead.
+- **Forced specificity**: Random numbers that don't add meaning
+
+## Punctuation
+
+Em dashes (—) are always closed—no surrounding spaces. Never ` — ` or ` - `.
+
+| Prefer        | When                                                           |
+| ------------- | -------------------------------------------------------------- |
+| Period (.)    | Default choice. Two sentences are often clearer than one.      |
+| Colon (:)     | Introducing explanation: "Here's the thing: it doesn't work"   |
+| Semicolon (;) | Related independent clauses: "The code works; the tests pass"  |
+| Em dash (—)   | Asides and emphasis, always closed: "It's fast—really fast"    |
+
+When in doubt, use a period.
+
+## How to Write Good Prose
+
+The previous sections say what to avoid. This section says what to do.
+
+### Lead with the point
+
+Every paragraph should open with its conclusion. Setup comes after, not before. The reader should know where you're going before you take them there.
+
+Bad (buries the point):
+
+> After investigating several approaches to conflict resolution, including CRDTs, operational transforms, and manual merge strategies, we found that Yjs with LWW timestamps gave us the best combination of correctness and simplicity.
+
+Good (leads with it):
+
+> Yjs with LWW timestamps gave us the best conflict resolution. We tried CRDTs without timestamps, operational transforms, and manual merge strategies; none matched it for correctness with this little code.
+
+### Vary sentence length
+
+Monotone sentence length is the fastest way to sound robotic. Mix short declarative sentences with longer explanatory ones. Short sentences punch. Longer ones carry nuance and connect ideas that need to live together.
+
+Bad (uniform length):
+
+> The system processes incoming events. It validates each event against the schema. It then routes the event to the appropriate handler. The handler updates the database accordingly.
+
+Good (varied rhythm):
+
+> The system validates incoming events against the schema and routes them to the right handler. Simple enough. But the handler has to update the database, notify subscribers, and maintain the audit log in a single transaction. That's where it gets interesting.
+
+### Use concrete language
+
+Abstract language forces the reader to do translation work. Concrete language lets them see it immediately.
+
+Bad (abstract):
+
+> This approach provides significant performance improvements for data retrieval operations.
+
+Good (concrete):
+
+> Row lookups dropped from O(n) to O(1). On a 10,000-row table, that's the difference between scanning every cell and a single hash lookup.
+
+### Connect ideas without headers
+
+Not every transition needs a section heading. Use bridge sentences: one sentence at the end of a paragraph that sets up the next topic, or one at the start that links back. Headers break the reader's flow; use them for major shifts, not every new thought.
+
+Bad (header-heavy):
+
+> ## The Problem
+> Sessions were timing out.
+>
+> ## The Root Cause
+> The refresh only triggered on navigation.
+>
+> ## The Solution
+> We added a keepalive to background activity.
+
+Good (flowing):
+
+> Sessions were timing out during file uploads. The refresh logic only triggered on navigation events, so any background activity—uploads, sync, long-running mutations—would silently lose the session.
+>
+> The fix was a keepalive that fires on any authenticated request, not just page transitions.
+
+## Common Rewrite Patterns
+
+Mechanical substitutions you can apply without judgment:
+
+| If you wrote...                              | Rewrite to...                              |
+| -------------------------------------------- | ------------------------------------------ |
+| "It's important to note that X"              | "X"                                        |
+| "In order to achieve Y, we need to Z"        | "Z gives us Y"                             |
+| "The reason this works is because..."        | "This works because..."                    |
+| "What this means is that..."                 | State it directly                          |
+| "It should be noted that..."                 | Drop it entirely                           |
+| "Basically, X"                               | "X"                                        |
+| "As mentioned earlier/above"                 | Just re-state the thing                    |
+| "This allows us to..."                       | "We can now..." or "Now X works"           |
+| "We need to make sure that..."               | "X must..." or just do it                  |
+| "In the context of..."                       | Drop it or be specific                     |
+| "It is worth mentioning that..."             | Mention it or don't                        |
+| "Going forward, we will..."                  | "Next: ..." or just describe the action    |
+| "leverage" / "utilize"                       | "use"                                      |
+| "facilitate"                                 | "let", "enable", or "allow"                |
+| "implement a solution"                       | "fix it" / "build it" / say what you built |
+
+## Explaining Technical Concepts
+
+When explaining how something works, show the mechanism, not the marketing. Lead with what happens, then why.
+
+Bad (over-explains, AI voice):
+
+> The key insight here is that by leveraging Yjs's built-in conflict resolution mechanism, we can effectively handle concurrent edits in a way that seamlessly maintains consistency across all connected clients.
+
+Good (direct, shows the mechanism):
+
+> Yjs resolves conflicts automatically. Two users edit the same field, both edits survive in the CRDT, and the LWW timestamp picks the winner. No manual merge logic needed.
+
+Bad (abstract):
+
+> The factory function pattern provides a clean separation of concerns by encapsulating the client creation logic and exposing a well-defined interface for consumers.
+
+Good (concrete):
+
+> `createSync()` takes a Y.Doc and returns three methods: `connect()`, `disconnect()`, and `status()`. The consumer never touches WebSocket setup, reconnection logic, or auth token refresh. They call `connect()` and it works.
+
+## Natural Prose
+
+- Write like a human telling a story, not a press kit.
+- Avoid emojis in headings and formal content unless explicitly requested
+
+## Open Source & Product Writing
+
+When writing landing pages or product-facing prose:
+
+- Start with what the tool actually does, not why it's amazing
+- Emphasize user control and data ownership
+- Highlight transparency: audit the code, no tracking, no middleman
+- Present honest cost comparisons with specific, real numbers
+- Acknowledge limitations and trade-offs openly
+- Use honest comparative language: "We believe X should be Y"
+- Present facts and let users draw conclusions
+
+## Good vs Bad Example
+
+Good (natural, human):
+
+"I was paying $30/month for a transcription app. Then I did the math: the actual API calls cost about $0.36/hour. At my usage (3-4 hours/day), I was paying $30 for what should cost $3.
+
+So I built Whispering to cut out the middleman. You bring your own API key, your audio goes directly to the provider, and you pay actual costs. No subscription, no data collection, no lock-in."
+
+Bad (AI-generated feel):
+
+"**Introducing Whispering** - A revolutionary transcription solution that empowers users with unprecedented control.
+
+**Key Benefits:**
+
+- **Cost-Effective**: Save up to 90% on transcription costs
+- **Privacy-First**: Your data never leaves your control
+- **Flexible**: Multiple provider options available
+
+**Why Whispering?** We believe transcription should be accessible to everyone..."
+
+The difference: story vs structured sections, personal vs corporate, specific numbers vs vague claims.
+
+## Voice Matching
+
+When the user provides example text or tone guidance, match it:
+
+- If they're terse, be terse
+- If they give 5 sentences, don't write 5 paragraphs
+- If they use direct statements, don't add narrative fluff
+- Match their energy, not a template

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 .DS_Store
+.agents/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,4 +6,4 @@ Structure: `src/result/` (Result types, trySync/tryAsync), `src/error/` (defineE
 
 Always use bun: `bun run`, `bun test`, `bun install`. Build with `bun run build` (tsdown). Format with `bun run format` (biome). Lint with `bun run lint` (biome). Typecheck with `bun run typecheck` (tsc).
 
-Skills: Task-specific instructions live in `.claude/skills/`. They are symlinked from the Epicenter repo (see README.md for setup). Load on-demand based on the task.
+Skills: Task-specific instructions live in `.claude/skills/`. Load on-demand based on the task.

--- a/README.md
+++ b/README.md
@@ -285,6 +285,23 @@ The same principle applies throughout: async/await instead of generators, `switc
 - **`Result<T, E>`** — union of `Ok<T> | Err<E>`
 - **`Brand<T, B>`** — branded type wrapper for distinct primitives
 
+## Development Setup
+
+### AI Agent Skills
+
+AI agent skills are managed via [`npx skills`](https://www.npmjs.com/package/skills), sourced from [Epicenter](https://github.com/EpicenterHQ/epicenter). Only skills relevant to wellcrafted's domain are installed.
+
+```bash
+# Install skills (already committed, but can be refreshed)
+npx skills add EpicenterHQ/epicenter --skill error-handling --skill define-errors -a claude-code -y
+
+# Update all installed skills
+npx skills update
+
+# List installed skills
+npx skills list
+```
+
 ## License
 
 MIT

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,105 @@
+{
+  "version": 1,
+  "skills": {
+    "control-flow": {
+      "source": "EpicenterHQ/epicenter",
+      "sourceType": "github",
+      "computedHash": "84eef70ffe87b484f05aff50fbcf6dcc2b57bf139a52c1d9dbc28d3cbec396d8"
+    },
+    "define-errors": {
+      "source": "EpicenterHQ/epicenter",
+      "sourceType": "github",
+      "computedHash": "a1fbe2a13b3d984dc4d1ace7dbde7e6bd1cf1853f050e6d50218c47c6d34f261"
+    },
+    "documentation": {
+      "source": "EpicenterHQ/epicenter",
+      "sourceType": "github",
+      "computedHash": "ef13dc06e07373b649f523ac6f101a882410d95078439ecc1ffba8df6b7e23f7"
+    },
+    "error-handling": {
+      "source": "EpicenterHQ/epicenter",
+      "sourceType": "github",
+      "computedHash": "9573172994a1877b5d599a93256559dd6e6f742596c02cefd1b6410af06ea193"
+    },
+    "factory-function-composition": {
+      "source": "EpicenterHQ/epicenter",
+      "sourceType": "github",
+      "computedHash": "c688003c35ced55eed158aa28ddb897e138084b9d2f05ef0a18874bc5f310810"
+    },
+    "git": {
+      "source": "EpicenterHQ/epicenter",
+      "sourceType": "github",
+      "computedHash": "6de2120d1a50c401bd7adcf265dc91abf4780ca8efb485d3ef397b15ff2339d6"
+    },
+    "honesty": {
+      "source": "EpicenterHQ/epicenter",
+      "sourceType": "github",
+      "computedHash": "4df5c59eb8a48525275a4fccadd2b65ba7eea414f35660ac5b5025f64a2d271b"
+    },
+    "incremental-commits": {
+      "source": "EpicenterHQ/epicenter",
+      "sourceType": "github",
+      "computedHash": "317ed5aa14b2ef0ee70078434ec8ad2e7457eeab7d4ec8496180902fdc2637e6"
+    },
+    "method-shorthand-jsdoc": {
+      "source": "EpicenterHQ/epicenter",
+      "sourceType": "github",
+      "computedHash": "3d5e57247ba5a8d884b253f8b754609b6c65de18dc1f5846ade3ccc8089ebcc0"
+    },
+    "progress-summary": {
+      "source": "EpicenterHQ/epicenter",
+      "sourceType": "github",
+      "computedHash": "fedbc60aaf10f9e1a255b9e62c99fcf19dc8186215acd261b0dc504faf8b0c45"
+    },
+    "query-layer": {
+      "source": "EpicenterHQ/epicenter",
+      "sourceType": "github",
+      "computedHash": "5bf873615791f2b6fbacf1033ad19b83348100befe296d9c3ac433b882f0072d"
+    },
+    "services-layer": {
+      "source": "EpicenterHQ/epicenter",
+      "sourceType": "github",
+      "computedHash": "f92460c2634c8c1781d63f58c25baa2d7aaf5424f09ccfdf0933a11eb91df530"
+    },
+    "single-or-array-pattern": {
+      "source": "EpicenterHQ/epicenter",
+      "sourceType": "github",
+      "computedHash": "727ef422a45fb941aba24cf1ce1595fde9d2917659001c0d6151df7b49aa4b37"
+    },
+    "spec-execution": {
+      "source": "EpicenterHQ/epicenter",
+      "sourceType": "github",
+      "computedHash": "b970f8b3055afdeacf1307a63020f08b1736b605e816694b3a1eeadfd3379837"
+    },
+    "specification-writing": {
+      "source": "EpicenterHQ/epicenter",
+      "sourceType": "github",
+      "computedHash": "bb77523e654fa285a1a9b6c0c16bea3fbedebec7cf9d7688b07886c6964c3ddf"
+    },
+    "technical-articles": {
+      "source": "EpicenterHQ/epicenter",
+      "sourceType": "github",
+      "computedHash": "9da35308b3dbaa6eef32283ba5812e837e0f900a0b72519f3341cfdeedd061c2"
+    },
+    "testing": {
+      "source": "EpicenterHQ/epicenter",
+      "sourceType": "github",
+      "computedHash": "1a07baa86c5fac4f946232ad34313eb43576d463913047747fc7914cbdc0230b"
+    },
+    "typescript": {
+      "source": "EpicenterHQ/epicenter",
+      "sourceType": "github",
+      "computedHash": "33c2ba5b14d29b198f5c8bc0759ba4c16fe125b042fb76ec98d7cb4f0c5ccf71"
+    },
+    "workflow": {
+      "source": "EpicenterHQ/epicenter",
+      "sourceType": "github",
+      "computedHash": "d224576c520c4f7c14a7d59689baba292c6fe9ed2e70e1a18be2a08ef8cc4b91"
+    },
+    "writing-voice": {
+      "source": "EpicenterHQ/epicenter",
+      "sourceType": "github",
+      "computedHash": "55d11a2595d6bd025221b4e86ed3acdef25ed2279717c6e0f3cd3b6cf4b8d502"
+    }
+  }
+}


### PR DESCRIPTION
Wellcrafted's AI agent skills were previously wired to the Epicenter repo through a two-level symlink chain that required a specific sibling directory layout on every developer's machine. This made the repo impossible to use standalone — cloning wellcrafted without epicenter sitting next to it broke all 42 skill references.

This replaces that fragile setup with `npx skills add EpicenterHQ/epicenter --copy`, which installs skill files directly into `.claude/skills/` as real, committed copies. No symlinks, no sibling directories, no setup ceremony.

```
Before:
.claude/skills → .agents/skills → ../../epicenter/.agents/skills
                                   (requires epicenter cloned alongside)
                                   (loads ALL 42 skills, 22 irrelevant)

After:
.claude/skills/<name>/SKILL.md    ← real files, committed
skills-lock.json                  ← tracks source + hashes for updates
```

### What changed

- **Deleted** the two symlinks (`.agents/skills`, `.claude/skills`) that pointed to epicenter
- **Installed** 20 domain-relevant skills via `npx skills add` with `--copy` flag
- **Dropped** 22 skills irrelevant to a TypeScript utility library (better-auth, svelte, tauri, drizzle-orm, yjs, styling, etc.)
- **Added** `skills-lock.json` — the skills CLI's lockfile that tracks source repo, skill names, and content hashes for `npx skills update`
- **Added** `.agents/` to `.gitignore` to prevent non-copy mode installs from polluting the repo
- **Updated** README.md with the new `npx skills` setup instructions
- **Updated** AGENTS.md to remove the symlink mention

### Why `npx skills` instead of manual copies

The [Vercel skills CLI](https://www.npmjs.com/package/skills) (`npx skills`) is the emerging standard for managing agent skills across Claude Code, Cursor, Codex, and 37+ other agents. Using it gives us:

1. **`npx skills update`** — one command to pull latest skill content from epicenter without re-specifying which skills to install
2. **`skills-lock.json`** — content hashes that make it trivial to check if skills are stale
3. **`npx skills list`** — visibility into what's installed
4. **Standard format** — skills use the universal `SKILL.md` frontmatter spec, compatible with any agent that supports the [Agent Skills specification](https://agentskills.io)

### Why `--copy` instead of default symlink mode

The skills CLI defaults to creating a canonical copy in `.agents/skills/` and symlinking from `.claude/skills/` → `.agents/skills/`. This is fine for local development but creates headaches with git — symlinks to directories confuse `git add` (the "beyond a symbolic link" error), and you end up committing two layers of indirection. `--copy` puts real files directly where Claude Code expects them. Simple.

### Why these 20 skills

Kept only skills whose domain overlaps with wellcrafted (a TypeScript utility library for error handling, Result types, and TanStack Query):

| Category | Skills |
|---|---|
| Core domain | `error-handling`, `define-errors`, `services-layer`, `query-layer` |
| Code style | `typescript`, `factory-function-composition`, `method-shorthand-jsdoc`, `single-or-array-pattern`, `control-flow` |
| Process | `testing`, `git`, `incremental-commits`, `workflow`, `spec-execution`, `specification-writing` |
| Documentation | `documentation`, `writing-voice`, `technical-articles`, `progress-summary` |
| Behavioral | `honesty` |

### Refreshing skills

```bash
# Update all installed skills to latest from epicenter
npx skills update

# Install additional skills
npx skills add EpicenterHQ/epicenter --skill <name> -a claude-code --copy -y

# List what's installed
npx skills list
```