### PR TITLE
feat(skills): ship 5 distributable agent skills for library users

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,8 @@
 
 Lightweight TypeScript library for type-safe error handling, Result types, branded types, and TanStack Query integration. Zero dependencies, < 2KB.
 
-Structure: `src/result/` (Result types, trySync/tryAsync), `src/error/` (defineErrors), `src/query/` (TanStack Query factories), `src/brand.ts` (branded types), `src/standard-schema/` (Standard Schema integration), `specs/` (planning docs), `docs/` (reference materials).
+Structure: `src/result/` (Result types, trySync/tryAsync), `src/error/` (defineErrors), `src/query/` (TanStack Query factories), `src/brand.ts` (branded types), `src/standard-schema/` (Standard Schema integration), `skills/` (distributable agent skills for library users), `specs/` (planning docs), `docs/` (reference materials).
 
 Always use bun: `bun run`, `bun test`, `bun install`. Build with `bun run build` (tsdown). Format with `bun run format` (biome). Lint with `bun run lint` (biome). Typecheck with `bun run typecheck` (tsc).
 
-Skills: Task-specific instructions live in `.claude/skills/`. Load on-demand based on the task.
+Skills: Internal skills for contributing to wellcrafted live in `.claude/skills/`. Distributable skills for users of the library live in `skills/` (installed via `npx skills add wellcrafted-dev/wellcrafted`).

--- a/README.md
+++ b/README.md
@@ -285,6 +285,27 @@ The same principle applies throughout: async/await instead of generators, `switc
 - **`Result<T, E>`** — union of `Ok<T> | Err<E>`
 - **`Brand<T, B>`** — branded type wrapper for distinct primitives
 
+## AI Agent Skills
+
+If you use an AI coding agent (Claude Code, Cursor, etc.), teach it how to use wellcrafted correctly:
+
+```bash
+npx skills add wellcrafted-dev/wellcrafted
+```
+
+This installs 5 skills that teach your agent the patterns, anti-patterns, and API conventions:
+
+| Skill | What it teaches |
+| --- | --- |
+| `define-errors` | `defineErrors` variants, `extractErrorMessage`, `InferErrors`/`InferError` type extraction |
+| `result-types` | `Ok`, `Err`, `trySync`/`tryAsync`, the `{ data, error }` destructuring pattern |
+| `query-factories` | `createQueryFactories`, `defineQuery`/`defineMutation`, dual interface (reactive + imperative) |
+| `branded-types` | `Brand<T>`, brand constructor pattern, when to add runtime validation |
+| `patterns` | Architectural style guide: control flow, factory composition, service layers, error composition |
+
+Skills work with any agent that supports [`npx skills`](https://www.npmjs.com/package/skills). Install once, update with `npx skills update`.
+
+
 ## Development Setup
 
 ### AI Agent Skills

--- a/skills/branded-types/SKILL.md
+++ b/skills/branded-types/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: branded-types
+description: Type-safe distinct primitives with Brand from wellcrafted. Use when creating nominal types for IDs, tokens, or any primitive that shouldn't be interchangeable.
+---
+
+# Branded Types
+
+```typescript
+import type { Brand } from 'wellcrafted/brand';
+```
+
+## The Problem
+
+TypeScript's structural typing lets you pass any `string` where another `string` is expected. A `UserId` and an `OrderId` are both strings — the compiler won't stop you from mixing them up.
+
+```typescript
+function getUser(id: string) { /* ... */ }
+function getOrder(id: string) { /* ... */ }
+
+const userId = '123';
+const orderId = '456';
+getUser(orderId); // No error — but wrong
+```
+
+## The Brand Type
+
+`Brand<T>` creates a phantom brand on a primitive. Two branded types from the same base are incompatible.
+
+```typescript
+type UserId = string & Brand<'UserId'>;
+type OrderId = string & Brand<'OrderId'>;
+
+function getUser(id: UserId) { /* ... */ }
+
+const userId = 'abc' as UserId;
+const orderId = 'xyz' as OrderId;
+getUser(userId);   // compiles
+getUser(orderId);  // type error
+```
+
+Zero runtime footprint — `Brand<T>` exists only at the type level.
+
+## Brand Constructor Pattern
+
+Never scatter `as UserId` casts across the codebase. Create a brand constructor — one function, one `as` cast, single source of truth.
+
+```typescript
+import type { Brand } from 'wellcrafted/brand';
+
+// 1. Define the branded type
+type UserId = string & Brand<'UserId'>;
+
+// 2. Create the brand constructor — THE ONLY place with `as UserId`
+// PascalCase matches the type name (TypeScript allows same-name type + value)
+function UserId(id: string): UserId {
+  return id as UserId;
+}
+
+// 3. Use everywhere
+const id = UserId('abc-123');
+getUser(UserId(rawString));
+```
+
+PascalCase constructors avoid parameter shadowing:
+
+```typescript
+// No shadowing — UserId() is PascalCase, userId is camelCase
+function processUser(userId: string) {
+  getUser(UserId(userId));
+}
+```
+
+## Adding Runtime Validation
+
+Brand constructors can validate before casting:
+
+```typescript
+function Email(value: string): Email {
+  if (!value.includes('@')) {
+    throw new Error(`Invalid email: ${value}`);
+  }
+  return value as Email;
+}
+type Email = string & Brand<'Email'>;
+```
+
+Add validation when the brand represents a constrained value (emails, UUIDs, positive numbers). Skip it when the brand is purely for identity distinction (UserId, OrderId).
+
+## Anti-Patterns
+
+### Scattered as casts
+
+```typescript
+// WRONG — assertions everywhere, no single source of truth
+const id = someString as UserId;           // file1.ts
+doSomething(otherId as UserId);            // file2.ts
+const parsed = key.split(':')[0] as UserId; // file3.ts
+
+// CORRECT — one constructor, used everywhere
+const id = UserId(someString);
+doSomething(UserId(otherId));
+const parsed = UserId(key.split(':')[0]);
+```
+
+### Missing constructor
+
+```typescript
+// WRONG — type exists but no constructor
+type PostId = string & Brand<'PostId'>;
+// Consumers forced to write `as PostId` everywhere
+
+// CORRECT — always pair the type with a constructor
+type PostId = string & Brand<'PostId'>;
+function PostId(id: string): PostId {
+  return id as PostId;
+}
+```
+
+## Naming Convention
+
+| Branded Type | Constructor |
+| --- | --- |
+| `UserId` | `UserId()` |
+| `OrderId` | `OrderId()` |
+| `Email` | `Email()` |
+| `ApiToken` | `ApiToken()` |
+
+The constructor uses PascalCase matching the type name. TypeScript allows a type and value to share the same name since they occupy different namespaces.
+
+See also: `patterns` skill for factory function patterns.

--- a/skills/define-errors/SKILL.md
+++ b/skills/define-errors/SKILL.md
@@ -1,0 +1,271 @@
+---
+name: define-errors
+description: Define typed, serializable error variants with defineErrors from wellcrafted. Use when creating error types, handling domain errors, or reviewing error definitions.
+---
+
+# defineErrors
+
+```typescript
+import {
+  defineErrors,
+  extractErrorMessage,
+  type InferErrors,
+  type InferError,
+} from 'wellcrafted/error';
+```
+
+## Core Rules
+
+1. All variants for a domain live in one `defineErrors` call — never spread across multiple calls
+2. The factory returns `{ message, ...fields }` — no `.withMessage()` or `.withContext()` chains
+3. `cause: unknown` is a field like any other — accept it in input, forward in return
+4. Call `extractErrorMessage(cause)` inside the factory, never at the call site
+5. Each call like `MyError.Variant({ ... })` returns `Err(...)` automatically
+6. Shadow the const with a same-name type using `InferErrors`
+7. Use `InferError<typeof MyError.Variant>` for a single variant's type
+8. Variant names describe the specific failure mode — never `Service`, `Error`, or `Failed`
+9. Aim for 2–5 variants per domain, each named by failure mode
+
+See also: `result-types` skill for `trySync`/`tryAsync` wrapping patterns.
+
+## Patterns
+
+### Zero-arg variant — static message
+
+```typescript
+const UserError = defineErrors({
+  AlreadyExists: () => ({
+    message: 'A user with this email already exists',
+  }),
+});
+type UserError = InferErrors<typeof UserError>;
+
+// Call site
+return UserError.AlreadyExists();
+```
+
+### Structured fields — message computed from input
+
+```typescript
+const DbError = defineErrors({
+  NotFound: ({ table, id }: { table: string; id: string }) => ({
+    message: `${table} '${id}' not found`,
+    table,
+    id,
+  }),
+});
+type DbError = InferErrors<typeof DbError>;
+
+// Call site
+return DbError.NotFound({ table: 'users', id: '123' });
+// error.message → "users '123' not found"
+// error.table   → "users"
+// error.id      → "123"
+```
+
+### Cause wrapping — extractErrorMessage inside the factory
+
+```typescript
+import { extractErrorMessage } from 'wellcrafted/error';
+
+const FileError = defineErrors({
+  ReadFailed: ({ path, cause }: { path: string; cause: unknown }) => ({
+    message: `Failed to read '${path}': ${extractErrorMessage(cause)}`,
+    path,
+    cause,
+  }),
+  WriteFailed: ({ path, cause }: { path: string; cause: unknown }) => ({
+    message: `Failed to write '${path}': ${extractErrorMessage(cause)}`,
+    path,
+    cause,
+  }),
+});
+type FileError = InferErrors<typeof FileError>;
+
+// Call site — pass the raw caught error, never call extractErrorMessage here
+catch: (error) => FileError.ReadFailed({ path: '/tmp/config.json', cause: error }),
+```
+
+### Multiple variants — discriminated union built-in
+
+```typescript
+const HttpError = defineErrors({
+  Connection: ({ url, cause }: { url: string; cause: unknown }) => ({
+    message: `Failed to connect to ${url}: ${extractErrorMessage(cause)}`,
+    url,
+    cause,
+  }),
+  Timeout: ({ url, ms }: { url: string; ms: number }) => ({
+    message: `Request to ${url} timed out after ${ms}ms`,
+    url,
+    ms,
+  }),
+  Response: ({ status, body }: { status: number; body: unknown }) => ({
+    message: `HTTP ${status}: ${extractErrorMessage(body)}`,
+    status,
+    body,
+  }),
+});
+type HttpError = InferErrors<typeof HttpError>;
+// HttpError is automatically the union of all three variants
+
+// Extracting a single variant type
+type TimeoutError = InferError<typeof HttpError.Timeout>;
+```
+
+### Composing errors across layers
+
+Each layer defines its own error vocabulary. Inner errors become `cause` fields in higher-level errors.
+
+```typescript
+// Low-level: HTTP errors
+const HttpError = defineErrors({
+  Connection: ({ url, cause }: { url: string; cause: unknown }) => ({
+    message: `Failed to connect to ${url}: ${extractErrorMessage(cause)}`,
+    url,
+    cause,
+  }),
+});
+
+// High-level: domain errors wrap HTTP errors via cause
+const UserError = defineErrors({
+  FetchFailed: ({ userId, cause }: { userId: string; cause: unknown }) => ({
+    message: `Failed to fetch user ${userId}: ${extractErrorMessage(cause)}`,
+    userId,
+    cause,
+  }),
+});
+
+// The HTTP error becomes cause in the domain error
+const { data, error } = await tryAsync({
+  try: () => fetch(`/api/users/${userId}`),
+  catch: (cause) => UserError.FetchFailed({ userId, cause }),
+});
+```
+
+See also: `patterns` skill for service layer architecture with error composition.
+
+## Type Extraction
+
+```typescript
+// Full union type for all variants
+type HttpError = InferErrors<typeof HttpError>;
+
+// Single variant type
+type ConnectionError = InferError<typeof HttpError.Connection>;
+```
+
+## Anti-Patterns
+
+### One defineErrors per variant
+
+```typescript
+// WRONG — defeats the namespace grouping
+const NotFoundError = defineErrors({ NotFound: () => ({ message: 'Not found' }) });
+const TimeoutError = defineErrors({ Timeout: () => ({ message: 'Timed out' }) });
+
+// CORRECT — all variants for a domain in one call
+const HttpError = defineErrors({
+  NotFound: () => ({ message: 'Not found' }),
+  Timeout: () => ({ message: 'Timed out' }),
+});
+```
+
+### extractErrorMessage at the call site
+
+```typescript
+// WRONG — call site does message extraction
+catch: (error) => MyError.Failed({ message: extractErrorMessage(error) });
+
+// CORRECT — pass raw cause, factory calls extractErrorMessage
+catch: (error) => MyError.Failed({ cause: error });
+```
+
+### Generic variant names
+
+```typescript
+// WRONG — "Service" says nothing about the failure mode
+const UserError = defineErrors({
+  Service: ({ message }: { message: string }) => ({ message }),
+});
+
+// CORRECT — name each variant by what actually went wrong
+const UserError = defineErrors({
+  AlreadyExists: ({ email }: { email: string }) => ({
+    message: `User ${email} already exists`,
+    email,
+  }),
+  CreateFailed: ({ cause }: { cause: unknown }) => ({
+    message: `Failed to create user: ${extractErrorMessage(cause)}`,
+    cause,
+  }),
+});
+```
+
+### Monolithic catch-all variant
+
+```typescript
+// WRONG — one variant with an operation string hides failure modes
+const DbError = defineErrors({
+  Failed: ({ operation, cause }: { operation: string; cause: unknown }) => ({
+    message: `Failed to ${operation}: ${extractErrorMessage(cause)}`,
+    operation,
+    cause,
+  }),
+});
+
+// CORRECT — each operation is its own variant
+const DbError = defineErrors({
+  QueryFailed: ({ cause }: { cause: unknown }) => ({
+    message: `Query failed: ${extractErrorMessage(cause)}`,
+    cause,
+  }),
+  InsertFailed: ({ cause }: { cause: unknown }) => ({
+    message: `Insert failed: ${extractErrorMessage(cause)}`,
+    cause,
+  }),
+});
+```
+
+### Discriminated union inputs (sub-discriminants)
+
+```typescript
+// WRONG — reason field creates a sub-discriminant, forces double narrowing
+const FormError = defineErrors({
+  Invalid: (input: {
+    reason: 'bad_email' | 'weak_password' | 'mismatch';
+    value?: string;
+  }) => ({
+    message: { bad_email: `Invalid email: '${input.value}'`, /* ... */ }[input.reason],
+    ...input,
+  }),
+});
+
+// CORRECT — each failure is its own variant with honest types
+const FormError = defineErrors({
+  InvalidEmail: ({ value }: { value: string }) => ({
+    message: `Invalid email: '${value}'`,
+    value,
+  }),
+  WeakPassword: () => ({
+    message: 'Password must be at least 8 characters',
+  }),
+  PasswordMismatch: () => ({
+    message: 'Passwords do not match',
+  }),
+});
+```
+
+### Conditional logic in factories
+
+If the factory branches on its inputs to decide the message, each branch should be its own variant. The branching is evidence that multiple errors are hiding in one.
+
+### Using ReturnType instead of InferErrors
+
+```typescript
+// WRONG
+type MyError = ReturnType<typeof MyError>;
+
+// CORRECT
+type MyError = InferErrors<typeof MyError>;
+```

--- a/skills/patterns/SKILL.md
+++ b/skills/patterns/SKILL.md
@@ -1,0 +1,360 @@
+---
+name: patterns
+description: Architectural patterns for code that uses wellcrafted. Covers control flow with trySync/tryAsync, factory function composition, service layers with Result types, error composition across boundaries, and the single-or-array pattern.
+---
+
+# Patterns
+
+A style guide for code that uses wellcrafted. Not API reference — architectural taste.
+
+## Human-Readable Control Flow
+
+Mirror natural human reasoning: try the thing, check if it failed, continue on the happy path.
+
+### Linearizing try-catch into guards
+
+Before — nested, mixed throw/return:
+
+```typescript
+async function handleRequest(userId: string) {
+  try {
+    const user = await fetchUser(userId);
+    const posts = await fetchPosts(user.id);
+    return Response.json({ user, posts });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return Response.json({ error: message }, { status: 500 });
+  }
+}
+```
+
+After — linear guards with `tryAsync`:
+
+```typescript
+import { tryAsync, Err } from 'wellcrafted/result';
+
+async function handleRequest(userId: string) {
+  const { data: user, error: userError } = await tryAsync({
+    try: () => fetchUser(userId),
+    catch: (cause) => UserError.FetchFailed({ userId, cause }),
+  });
+  if (userError) return Response.json({ error: userError.message }, { status: 502 });
+
+  const { data: posts, error: postsError } = await tryAsync({
+    try: () => fetchPosts(user.id),
+    catch: (cause) => PostError.FetchFailed({ userId: user.id, cause }),
+  });
+  if (postsError) return Response.json({ error: postsError.message }, { status: 502 });
+
+  return Response.json({ user, posts });
+}
+```
+
+Each guard has the same shape: do the thing → check → return early on failure. The happy path accumulates at the bottom.
+
+### Natural-language boolean variables
+
+Name booleans so they read like thoughts:
+
+```typescript
+const isAuthenticated = session && !session.expired;
+const needsRefresh = token.expiresAt < Date.now() + BUFFER_MS;
+const canSkipValidation = input.source === 'trusted' && input.validated;
+
+if (!isAuthenticated) return Response.json({ error: 'Unauthorized' }, { status: 401 });
+if (needsRefresh) await refreshToken(token);
+```
+
+### Early returns as guard clauses
+
+```typescript
+async function createUser(email: string): Promise<Result<User, UserError>> {
+  // Guard: validate input
+  if (!email.includes('@')) return UserError.InvalidEmail({ email });
+
+  // Guard: check uniqueness
+  const existing = await db.findByEmail(email);
+  if (existing) return UserError.AlreadyExists({ email });
+
+  // Happy path
+  return tryAsync({
+    try: () => db.users.create({ email }),
+    catch: (cause) => UserError.CreateFailed({ email, cause }),
+  });
+}
+```
+
+## Factory Function Composition
+
+### The universal signature
+
+Every factory function follows this shape:
+
+```typescript
+function createSomething(dependencies, options?) {
+  return { /* methods */ };
+}
+```
+
+Two arguments max. First is resources, second is config. Dependencies come first because they're what makes the factory reusable — the same factory with different deps produces different behavior.
+
+```typescript
+// Single dependency
+function createUserService(db: Database) {
+  return {
+    getById(userId: string) { /* uses db */ },
+    create(data: CreateUserInput) { /* uses db */ },
+  };
+}
+
+// Multiple dependencies
+function createNotificationService({ email, sms }: { email: EmailClient; sms: SmsClient }) {
+  return {
+    notify(userId: string, message: string) { /* uses email, sms */ },
+  };
+}
+```
+
+### Separating option layers
+
+Each layer owns its own configuration. Don't mix them.
+
+```typescript
+// WRONG — mixed options blob
+sendEmail({
+  timeout: 5000,     // client option
+  retries: 3,        // client option
+  to: 'alice@co.com', // method option
+  subject: 'Hello',   // method option
+});
+
+// CORRECT — each layer has its own options
+const client = createEmailClient({ timeout: 5000, retries: 3 });
+const service = createEmailService(client);
+service.send({ to: 'alice@co.com', subject: 'Hello' });
+```
+
+### Anti-patterns
+
+```typescript
+// WRONG — client creation hidden inside
+function sendEmail(clientOptions: ClientOpts, emailOptions: EmailOpts) {
+  const client = createClient(clientOptions); // Hidden!
+  return client.send(emailOptions);
+}
+
+// CORRECT — visible dependency chain
+const client = createEmailClient(clientOptions);
+const service = createEmailService(client);
+service.send(emailOptions);
+```
+
+```typescript
+// WRONG — function takes client as first argument everywhere
+function getUser(db: Database, userId: string) { ... }
+function createUser(db: Database, data: UserInput) { ... }
+
+// CORRECT — factory captures the dependency
+const userService = createUserService(db);
+userService.getById(userId);
+userService.create(data);
+```
+
+### Internal zone ordering
+
+Inside a factory, organize code in four zones:
+
+```typescript
+function createUserService(db: Database, options?: { maxRetries?: number }) {
+  // Zone 1 — Immutable state (const from deps/options)
+  const maxRetries = options?.maxRetries ?? 3;
+
+  // Zone 2 — Mutable state (let declarations)
+  let connectionCount = 0;
+
+  // Zone 3 — Private helpers (not exposed)
+  function withRetry<T>(fn: () => Promise<T>): Promise<T> { /* ... */ }
+
+  // Zone 4 — Public API (always last)
+  return {
+    async getById(userId: string): Promise<Result<User, UserError>> { /* ... */ },
+    async create(data: CreateUserInput): Promise<Result<User, UserError>> { /* ... */ },
+  };
+}
+```
+
+The return object is always last — it's the complete public API.
+
+## Service Layer Pattern
+
+Services are factory functions that return objects with methods returning `Result<T, E>`. Each service defines its own error vocabulary with `defineErrors`.
+
+### Complete example
+
+```typescript
+import { defineErrors, extractErrorMessage, type InferErrors } from 'wellcrafted/error';
+import { Ok, tryAsync, type Result } from 'wellcrafted/result';
+
+// 1. Define domain errors
+const UserError = defineErrors({
+  NotFound: ({ userId }: { userId: string }) => ({
+    message: `User ${userId} not found`,
+    userId,
+  }),
+  CreateFailed: ({ email, cause }: { email: string; cause: unknown }) => ({
+    message: `Failed to create user ${email}: ${extractErrorMessage(cause)}`,
+    email,
+    cause,
+  }),
+  FetchFailed: ({ cause }: { cause: unknown }) => ({
+    message: `Failed to fetch users: ${extractErrorMessage(cause)}`,
+    cause,
+  }),
+});
+type UserError = InferErrors<typeof UserError>;
+
+// 2. Factory function returns service object
+function createUserService(db: Database) {
+  return {
+    async getById(userId: string): Promise<Result<User, UserError>> {
+      const { data: user, error } = await tryAsync({
+        try: () => db.users.findById(userId),
+        catch: (cause) => UserError.FetchFailed({ cause }),
+      });
+      if (error) return error;
+      if (!user) return UserError.NotFound({ userId });
+      return Ok(user);
+    },
+
+    async create(email: string): Promise<Result<User, UserError>> {
+      return tryAsync({
+        try: () => db.users.insert({ email }),
+        catch: (cause) => UserError.CreateFailed({ email, cause }),
+      });
+    },
+  };
+}
+
+// 3. Export factory + Live instance
+type UserService = ReturnType<typeof createUserService>;
+const UserServiceLive = createUserService(productionDb);
+```
+
+The factory is for testing (inject mocks), the Live instance is for production.
+
+### Namespace re-exports
+
+Organize services hierarchically:
+
+```typescript
+// services/index.ts
+import { UserServiceLive } from './user';
+import { PostServiceLive } from './post';
+
+export const services = {
+  users: UserServiceLive,
+  posts: PostServiceLive,
+} as const;
+```
+
+## Error Composition Across Layers
+
+Each layer defines its own error vocabulary. Inner errors become `cause` fields in higher-level errors. `extractErrorMessage` formats them inside the factory.
+
+```typescript
+// Layer 1: HTTP client errors
+const HttpError = defineErrors({
+  Connection: ({ url, cause }: { url: string; cause: unknown }) => ({
+    message: `Failed to connect to ${url}: ${extractErrorMessage(cause)}`,
+    url,
+    cause,
+  }),
+  Response: ({ url, status }: { url: string; status: number }) => ({
+    message: `${url} returned HTTP ${status}`,
+    url,
+    status,
+  }),
+});
+
+// Layer 2: domain service wraps HTTP errors via cause
+const UserError = defineErrors({
+  FetchFailed: ({ userId, cause }: { userId: string; cause: unknown }) => ({
+    message: `Failed to fetch user ${userId}: ${extractErrorMessage(cause)}`,
+    userId,
+    cause,
+  }),
+});
+
+// The HTTP error becomes cause in the domain error
+async function getUser(userId: string): Promise<Result<User, UserError>> {
+  const { data: response, error } = await tryAsync({
+    try: () => fetch(`/api/users/${userId}`),
+    catch: (cause) => UserError.FetchFailed({ userId, cause }),
+    //                 raw fetch error ^^^^ becomes cause
+  });
+  if (error) return error;
+
+  if (response.status === 404) return UserError.NotFound({ userId });
+
+  return tryAsync({
+    try: () => response.json() as Promise<User>,
+    catch: (cause) => UserError.FetchFailed({ userId, cause }),
+  });
+}
+```
+
+The full error chain is JSON-serializable at every level. Log it, send it over the wire, display it in a toast.
+
+See also: `define-errors` skill for error variant definitions. `result-types` skill for trySync/tryAsync patterns.
+
+## The Single-or-Array Pattern
+
+Accept both single items and arrays, normalize at the top, process uniformly.
+
+```typescript
+function deleteUsers(userOrUsers: User | User[]): Promise<Result<void, DbError>> {
+  const users = Array.isArray(userOrUsers) ? userOrUsers : [userOrUsers];
+
+  // One code path for both cases
+  const ids = users.map((u) => u.id);
+  return tryAsync({
+    try: () => db.users.bulkDelete(ids),
+    catch: (cause) => DbError.DeleteFailed({ cause }),
+  });
+}
+
+// Works with one
+await deleteUsers(user);
+
+// Works with many
+await deleteUsers([user1, user2, user3]);
+```
+
+### Naming convention
+
+| Parameter | Normalized Variable |
+| --- | --- |
+| `userOrUsers` | `users` |
+| `itemOrItems` | `items` |
+| `postOrPosts` | `posts` |
+
+### Anti-patterns
+
+```typescript
+// WRONG — separate functions for single vs array
+function deleteUser(user: User): Promise<...>;
+function deleteUsers(users: User[]): Promise<...>;
+
+// WRONG — forcing arrays everywhere
+deleteUsers([user]); // awkward for single items
+
+// WRONG — duplicated logic in overloads
+function deleteUser(user: User) { return db.delete(user.id); }
+function deleteUsers(users: User[]) { return db.bulkDelete(users.map(u => u.id)); }
+
+// CORRECT — single implementation
+function deleteUsers(userOrUsers: User | User[]) {
+  const users = Array.isArray(userOrUsers) ? userOrUsers : [userOrUsers];
+  return db.bulkDelete(users.map((u) => u.id));
+}
+```

--- a/skills/query-factories/SKILL.md
+++ b/skills/query-factories/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: query-factories
+description: TanStack Query integration with wellcrafted's createQueryFactories, defineQuery, and defineMutation. Use when setting up queries/mutations that return Result types or using the dual interface pattern.
+---
+
+# Query Factories
+
+```typescript
+import { createQueryFactories } from 'wellcrafted/query';
+```
+
+## Setup
+
+`createQueryFactories` takes a TanStack `QueryClient` and returns `defineQuery` and `defineMutation`:
+
+```typescript
+import { QueryClient } from '@tanstack/react-query'; // or @tanstack/svelte-query
+import { createQueryFactories } from 'wellcrafted/query';
+
+const queryClient = new QueryClient();
+const { defineQuery, defineMutation } = createQueryFactories(queryClient);
+```
+
+## defineQuery
+
+Define a query whose `queryFn` returns a `Result<T, E>`:
+
+```typescript
+import { Ok, Err, type Result } from 'wellcrafted/result';
+
+const userQuery = defineQuery({
+  queryKey: ['users', userId],
+  queryFn: async (): Promise<Result<User, UserError>> => {
+    const { data, error } = await getUser(userId);
+    if (error) {
+      return Err({
+        title: 'Failed to load user',
+        description: error.message,
+      });
+    }
+    return Ok(data);
+  },
+});
+```
+
+## defineMutation
+
+Same pattern for mutations:
+
+```typescript
+const createPost = defineMutation({
+  mutationFn: async (input: { title: string; body: string }) => {
+    const { data, error } = await postService.create(input);
+    if (error) {
+      return Err({
+        title: 'Failed to create post',
+        description: error.message,
+      });
+    }
+    return Ok(data);
+  },
+});
+```
+
+## Dual Interface
+
+Every query and mutation provides two ways to use it — reactive and imperative.
+
+### Reactive: `.options`
+
+Pass `.options` to your framework's query hook. It's a static object — wrap it in an accessor for Svelte, pass directly in React.
+
+```typescript
+// React
+import { useQuery, useMutation } from '@tanstack/react-query';
+
+const query = useQuery(userQuery.options);
+const mutation = useMutation(createPost.options);
+```
+
+```typescript
+// Svelte
+import { createQuery, createMutation } from '@tanstack/svelte-query';
+
+const query = createQuery(() => userQuery.options);
+const mutation = createMutation(() => createPost.options);
+```
+
+### Imperative: `.fetch()` / `.execute()`
+
+Use in event handlers and workflows without reactive overhead:
+
+```typescript
+// Queries use .fetch()
+const { data, error } = await userQuery.fetch();
+
+// Mutations use .execute()
+const { data, error } = await createPost.execute({
+  title: 'Hello',
+  body: 'World',
+});
+```
+
+### When to use each
+
+| `.options` (reactive) | `.fetch()` / `.execute()` (imperative) |
+| --- | --- |
+| Component data display | Event handlers |
+| Loading/error states | Sequential workflows |
+| Auto-refetch | One-time operations |
+| Cache synchronization | Outside component context |
+
+## Error Transformation
+
+Transform service errors into user-facing errors at the query boundary. Service errors describe what went wrong technically; user-facing errors describe what to show the user.
+
+```typescript
+const userQuery = defineQuery({
+  queryKey: ['users', userId],
+  queryFn: async () => {
+    // Service returns technical error (UserError.NotFound, UserError.FetchFailed)
+    const { data, error } = await getUser(userId);
+
+    if (error) {
+      // Transform to user-facing error
+      return Err({
+        title: 'Failed to load user',
+        description: error.message,
+      });
+    }
+
+    return Ok(data);
+  },
+});
+```
+
+### Anti-pattern: returning raw service errors
+
+```typescript
+// WRONG — raw service errors leak into the UI layer
+const userQuery = defineQuery({
+  queryKey: ['users', userId],
+  queryFn: () => getUser(userId), // Raw UserError reaches components
+});
+
+// CORRECT — transform at the boundary
+const userQuery = defineQuery({
+  queryKey: ['users', userId],
+  queryFn: async () => {
+    const { data, error } = await getUser(userId);
+    if (error) return Err({ title: 'Failed to load user', description: error.message });
+    return Ok(data);
+  },
+});
+```
+
+## Query Key Organization
+
+Organize keys hierarchically for targeted cache invalidation:
+
+```typescript
+const userKeys = {
+  all: ['users'] as const,
+  lists: ['users', 'list'] as const,
+  byId: (id: string) => ['users', id] as const,
+  posts: (id: string) => ['users', id, 'posts'] as const,
+};
+```
+
+Invalidating `['users']` clears everything; invalidating `['users', id]` clears just that user.
+
+## Cache Management
+
+Optimistic updates for instant UI feedback:
+
+```typescript
+const updateUser = defineMutation({
+  mutationFn: async (input: { userId: string; name: string }) => {
+    const { data, error } = await userService.update(input);
+    if (error) return Err({ title: 'Failed to update user', description: error.message });
+
+    // Optimistic cache update
+    queryClient.setQueryData<User>(
+      userKeys.byId(input.userId),
+      (old) => old ? { ...old, name: input.name } : old,
+    );
+
+    // Invalidate to refetch fresh data in background
+    queryClient.invalidateQueries({ queryKey: userKeys.all });
+
+    return Ok(data);
+  },
+});
+```
+
+See also: `result-types` skill for the Result type pattern. `define-errors` skill for creating error variants.

--- a/skills/result-types/SKILL.md
+++ b/skills/result-types/SKILL.md
@@ -1,0 +1,263 @@
+---
+name: result-types
+description: Working with Result types, Ok, Err, trySync, tryAsync, and utility functions from wellcrafted. Use when wrapping unsafe code, handling errors with Results, or destructuring { data, error } responses.
+---
+
+# Result Types
+
+```typescript
+import { Ok, Err, trySync, tryAsync, type Result } from 'wellcrafted/result';
+```
+
+## The Shape
+
+Results are plain objects with two properties — `data` and `error`. One is always `null`.
+
+```typescript
+type Ok<T>  = { data: T; error: null };
+type Err<E> = { error: E; data: null };
+type Result<T, E> = Ok<T> | Err<E>;
+```
+
+This is the same destructuring shape used by Supabase and SvelteKit load functions. Check `error` first, and TypeScript narrows `data` automatically:
+
+```typescript
+const { data, error } = await someOperation();
+if (error) {
+  // error is E, data is null
+  return;
+}
+// data is T, error is null
+```
+
+## Constructors
+
+```typescript
+// Success
+const result = Ok({ id: '123', name: 'Alice' });
+
+// Failure
+const result = Err({ name: 'NotFound', message: 'User not found' });
+
+// Void success — use Ok(undefined)
+const result = Ok(undefined);
+```
+
+## trySync and tryAsync
+
+Wrap throwing operations into Results. The `catch` handler receives the raw error and returns an error variant.
+
+```typescript
+import { defineErrors, extractErrorMessage } from 'wellcrafted/error';
+
+const JsonError = defineErrors({
+  ParseFailed: ({ input, cause }: { input: string; cause: unknown }) => ({
+    message: `Invalid JSON: ${extractErrorMessage(cause)}`,
+    input: input.slice(0, 100),
+    cause,
+  }),
+});
+
+// Synchronous
+const { data, error } = trySync({
+  try: () => JSON.parse(rawInput),
+  catch: (cause) => JsonError.ParseFailed({ input: rawInput, cause }),
+});
+
+// Asynchronous — always await
+const { data, error } = await tryAsync({
+  try: () => fetch(url).then((r) => r.json()),
+  catch: (cause) => HttpError.Connection({ url, cause }),
+});
+```
+
+See also: `define-errors` skill for creating error variants.
+
+## Key Rules
+
+1. Use `trySync` for synchronous code, `tryAsync` for async
+2. Always `await` tryAsync — it returns a Promise
+3. Match return types — if try returns `T`, catch should return `Err<E>` or `Ok<T>` for recovery
+4. Use `Ok(undefined)` for void operations
+5. Return `Err(error)` to propagate errors up the chain
+6. Pass the raw caught error as `cause` — let the error factory call `extractErrorMessage`
+
+## Recovery Pattern
+
+When `catch` returns `Ok(fallback)` instead of `Err`, the return type narrows to `Ok<T>` — no error checking needed:
+
+```typescript
+const { data: config } = trySync({
+  try: (): unknown => JSON.parse(configJson),
+  catch: () => Ok({ theme: 'dark', fontSize: 14 }),
+});
+// config is always defined — the catch recovered
+```
+
+```typescript
+// File existence check with fallback
+const { data: exists } = trySync({
+  try: () => fs.existsSync(path),
+  catch: () => Ok(false),
+});
+```
+
+## Wrapping Guidelines
+
+### Minimal wrap — only the risky operation
+
+```typescript
+// CORRECT: Wrap only the call that can throw
+const { data: response, error } = await tryAsync({
+  try: () => fetch(`/api/users/${userId}`),
+  catch: (cause) => UserError.FetchFailed({ userId, cause }),
+});
+if (error) return Err(error);
+
+// Continue with non-throwing operations
+const user = await response.json();
+return Ok(user);
+```
+
+```typescript
+// WRONG: Wrapping too much
+const { data, error } = await tryAsync({
+  try: async () => {
+    const response = await fetch(`/api/users/${userId}`);
+    const user = await response.json();
+    await updateCache(user);
+    return user;
+  },
+  catch: (error) => Err(error), // Too vague
+});
+```
+
+### Immediate return pattern
+
+Return errors immediately after checking. This creates linear control flow.
+
+```typescript
+// CORRECT: Check and return immediately
+const { data: user, error: fetchError } = await getUser(userId);
+if (fetchError) return Err(fetchError);
+
+const { data: posts, error: postsError } = await getPosts(user.id);
+if (postsError) return Err(postsError);
+
+return Ok({ user, posts });
+```
+
+```typescript
+// WRONG: Nested error handling
+const { data: user, error: fetchError } = await getUser(userId);
+if (!fetchError) {
+  const { data: posts, error: postsError } = await getPosts(user.id);
+  if (!postsError) {
+    return Ok({ user, posts });
+  } else {
+    return Err(postsError);
+  }
+} else {
+  return Err(fetchError);
+}
+```
+
+### When to extend the try block
+
+Include multiple operations in one block when they must succeed or fail together:
+
+```typescript
+// Atomic operation — all steps are part of "save document"
+const { data, error } = await tryAsync({
+  try: async () => {
+    const validated = schema.parse(document);
+    const saved = await db.documents.insert(validated);
+    await index.add(saved.id, saved.content);
+    return saved;
+  },
+  catch: (cause) => DbError.InsertFailed({ cause }),
+});
+```
+
+## The Destructured-Error Gotcha
+
+When you destructure `{ data, error }`, the `error` variable is the raw error value — NOT wrapped in `Err`. You must wrap it before returning from a function that returns `Result`:
+
+```typescript
+// WRONG — error is the raw value, not a Result
+const { data, error } = await tryAsync({ ... });
+if (error) return error; // Type error: returns raw error, not Result
+
+// CORRECT — wrap with Err() to return a proper Result
+const { data, error } = await tryAsync({ ... });
+if (error) return Err(error);
+```
+
+This is different from returning the entire result object:
+
+```typescript
+// Also correct — result is already a Result type
+const result = await tryAsync({ ... });
+if (result.error) return result; // Returns the full Result
+```
+
+## Utility Functions
+
+### isOk / isErr — type guards
+
+```typescript
+import { isOk, isErr } from 'wellcrafted/result';
+
+const result = await getUser(userId);
+
+if (isOk(result)) {
+  console.log(result.data.name);
+}
+
+if (isErr(result)) {
+  console.log(result.error.message);
+}
+```
+
+### unwrap — extract data or throw
+
+```typescript
+import { unwrap } from 'wellcrafted/result';
+
+// Returns data if Ok, throws error if Err
+const user = unwrap(await getUser(userId));
+```
+
+Use sparingly — `unwrap` throws, which defeats the purpose of Result types. Useful in tests and scripts where you know the operation should succeed.
+
+### resolve — handle values that may or may not be Results
+
+```typescript
+import { resolve } from 'wellcrafted/result';
+
+// If value is a Result, returns it as-is
+// If value is not a Result, wraps it in Ok()
+const result = resolve(maybeResult);
+```
+
+### partitionResults — split an array of Results
+
+```typescript
+import { partitionResults } from 'wellcrafted/result';
+
+const results = await Promise.all(userIds.map(getUser));
+const { ok, err } = partitionResults(results);
+// ok:  User[]        — just the successful values
+// err: UserError[]   — just the errors
+```
+
+## Wrapping Summary
+
+| Scenario | Approach |
+| --- | --- |
+| Single risky operation | Wrap just that operation |
+| Sequential operations | Wrap each separately, return immediately on error |
+| Atomic operations | Wrap together in one block |
+| Different error types | Separate blocks with appropriate error types |
+
+See also: `define-errors` skill for error variant definitions. `patterns` skill for service architecture.

--- a/specs/20260311T124200-distributable-agent-skills.md
+++ b/specs/20260311T124200-distributable-agent-skills.md
@@ -1,7 +1,7 @@
 # Distributable Agent Skills
 
 **Date**: 2026-03-11
-**Status**: Approved
+**Status**: Implemented
 **Author**: AI-assisted
 
 ## Overview
@@ -258,9 +258,9 @@ Each skill follows these principles (from writing-voice):
 
 ### Phase 3: Documentation and testing
 
-- [ ] **3.1** Update README.md with skills installation section
-- [ ] **3.2** Test installation: `npx skills add . --list` shows all 5 skills
-- [ ] **3.3** Test installation: `npx skills add . --skill define-errors -a claude-code -y` works
+- [x] **3.1** Update README.md with skills installation section
+- [x] **3.2** Test installation: `npx skills add . --list` shows all 5 skills
+- [x] **3.3** Test installation: `npx skills add . --skill define-errors -a claude-code -y` works
 
 ## Open Questions
 
@@ -297,3 +297,31 @@ Each skill follows these principles (from writing-voice):
 - `.claude/skills/single-or-array-pattern/SKILL.md` — primary source for patterns skill (single-or-array section)
 - `README.md` — current API documentation and examples
 - `npx skills --help` — CLI documentation
+
+## Review
+
+**Completed**: 2026-03-11
+**Branch**: main
+
+### Summary
+
+Shipped 5 distributable agent skills in `skills/` alongside the wellcrafted npm package. Each skill is adapted from internal `.claude/skills/` with all project-specific references (Whispering, RecorderError, DeviceStreamError, FfmpegError, Tauri, Elysia) replaced by generic domains (HttpError, DbError, UserError, FileError, JsonError). README updated with `npx skills add wellcrafted-dev/wellcrafted` installation instructions.
+
+### Skills Created
+
+| Skill | Lines | Source |
+| --- | --- | --- |
+| `define-errors` | 272 | Adapted from `.claude/skills/define-errors/` |
+| `result-types` | 264 | Adapted from `.claude/skills/error-handling/` + new content |
+| `query-factories` | 197 | Adapted from `.claude/skills/query-layer/` |
+| `branded-types` | 131 | Extracted from `.claude/skills/typescript/` branded types section |
+| `patterns` | 361 | Merged from control-flow, factory-function-composition, services-layer, single-or-array-pattern |
+
+### Deviations from Spec
+
+- None. All 5 skills written as specified, all using generic domains, all discovered by `npx skills add . --list`.
+
+### Follow-up Work
+
+- Consider adding a `testing` skill for wellcrafted's test patterns once the library has more test utilities
+- Monitor `npx skills update` behavior when skills are updated on main branch

--- a/specs/20260311T124200-distributable-agent-skills.md
+++ b/specs/20260311T124200-distributable-agent-skills.md
@@ -1,0 +1,299 @@
+# Distributable Agent Skills
+
+**Date**: 2026-03-11
+**Status**: Approved
+**Author**: AI-assisted
+
+## Overview
+
+Ship AI agent skills alongside the wellcrafted npm package so that any project using wellcrafted can teach their coding agents how to use it correctly. Users install with `npx skills add wellcrafted-dev/wellcrafted`.
+
+## Motivation
+
+### Current State
+
+wellcrafted has 20 skills in `.claude/skills/` that teach agents how to use the library. They're excellent — detailed patterns, anti-patterns, real code examples. But they're locked to this repo. They reference Whispering-specific code (`apps/whispering/src/lib/services/...`), internal architecture (`RecorderService`, `DeviceStreamError`), and project-specific patterns (Tauri, platform detection).
+
+A developer who `npm install wellcrafted` gets the library but their AI agent has no idea how to use it. The agent will guess at patterns, produce `as any` casts, miss the `{ data, error }` destructuring idiom, and create class-based errors instead of `defineErrors` variants.
+
+### Desired State
+
+```bash
+npm install wellcrafted              # the library
+npx skills add wellcrafted-dev/wellcrafted  # teach your agent how to use it
+```
+
+After installing skills, an agent writing code in the user's project knows:
+- How to define error variants with `defineErrors` (and what NOT to do)
+- How to wrap unsafe code with `trySync`/`tryAsync`
+- How to use `Ok`, `Err`, and the `{ data, error }` destructuring pattern
+- How to compose errors across service boundaries
+- How to use `Brand<T>` with brand constructors
+- How to set up TanStack Query with wellcrafted's dual interface
+
+## Research Findings
+
+### How `npx skills` Works
+
+The CLI (by Vercel Labs) supports any GitHub repository as a skill source. No registry, no approval process.
+
+| Aspect | How it works |
+|---|---|
+| Discovery | Scans `skills/`, root, `curated/skills/`, agent-specific dirs for `SKILL.md` files |
+| File format | Markdown with YAML frontmatter (`name`, `description`) |
+| Installation | Copies/symlinks into `.claude/skills/`, `.cursor/rules/`, etc. |
+| Selection | Interactive: user picks which skills and which agents |
+| Updates | `npx skills update` pulls latest from the repo |
+
+Publishing is push-to-GitHub: `npx skills add <owner>/<repo>`.
+
+### Existing Skill Content Audit
+
+Reviewed all 20 `.claude/skills/` to classify what's distributable vs project-specific.
+
+**Directly distributable (wellcrafted API patterns):**
+
+| Current skill | What it teaches | Adaptation needed |
+|---|---|---|
+| `define-errors` | `defineErrors` API, variant patterns, anti-patterns | Strip Whispering examples, use generic domains |
+| `error-handling` | `trySync`/`tryAsync`, wrapping patterns | Remove Elysia/handler-specific sections, generalize |
+| `services-layer` | Service architecture with Result types | Heavy rewrite — too Whispering-specific |
+| `query-layer` | TanStack Query integration | Moderate rewrite — remove Whispering RPC structure |
+
+**Partially distributable (general patterns using wellcrafted):**
+
+| Current skill | Assessment |
+|---|---|
+| `control-flow` | Good patterns but only tangentially wellcrafted-specific |
+| `factory-function-composition` | General TS pattern, not wellcrafted-specific |
+| `single-or-array-pattern` | General TS pattern, not wellcrafted-specific |
+| `typescript` | Brand types section is relevant; rest is general style |
+
+**Not distributable (project/framework-specific):**
+
+`workflow`, `specification-writing`, `writing-voice`, `honesty`, `git`, `incremental-commits`, `progress-summary`, `testing`, `social-media`, `technical-articles`, `github-issues`, `method-shorthand-jsdoc`, `monorepo`, `spec-execution`, `svelte`, `elysia`, `tauri`, `drizzle-orm`, `arktype`, `typebox`, `yjs`, `workspace-api`, `styling`, `frontend-design`, `web-design-guidelines`, all `better-auth-*`, `create-auth-skill`, `rust-errors`, `sync-construction-async-property-ui-render-gate-pattern`
+
+### How Other Libraries Ship Skills
+
+No major npm library currently ships agent skills alongside code. This would be a first-mover pattern. The closest analogs are:
+- `vercel-labs/agent-skills` — standalone skill repos (not library-attached)
+- Project-specific `.claude/skills/` — not distributed
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Skill directory | `skills/` at repo root | Standard location for `npx skills` discovery |
+| Skill granularity | One skill per package export + one style guide | Maps to `wellcrafted/error`, `wellcrafted/result`, etc. plus a `patterns` skill for architectural taste |
+| Naming | `define-errors`, `result-types`, `query-factories`, `branded-types`, `patterns` | Descriptive, matches API concepts. No `wellcrafted-` prefix — repo context provides that (same convention as vercel-labs) |
+| Internal skills | Keep `.claude/skills/` as-is | Project-specific patterns still needed for contributing to wellcrafted itself |
+| Example domains | HTTP clients, user services, file operations | Universal, no framework dependency |
+| Skill voice | Direct, concrete, pattern-focused | Follows writing-voice: lead with the point, show mechanism not marketing |
+| Anti-patterns | Include prominently | The "what NOT to do" sections are the most valuable part for agents |
+| Style guide skill | Bundle control-flow, factory composition, service layer into one `patterns` skill | Architectural taste that complements the API reference skills |
+
+## Architecture
+
+```
+wellcrafted/
+├── .claude/skills/          ← Internal: for contributing to wellcrafted
+│   ├── define-errors/
+│   ├── error-handling/
+│   ├── services-layer/
+│   └── ... (20 skills)
+│
+├── skills/                  ← Distributable: for USERS of wellcrafted
+│   ├── define-errors/
+│   │   └── SKILL.md
+│   ├── result-types/
+│   │   └── SKILL.md
+│   ├── query-factories/
+│   │   └── SKILL.md
+│   ├── branded-types/
+│   │   └── SKILL.md
+│   └── patterns/
+│       └── SKILL.md
+│
+├── src/                     ← Library source
+│   ├── error/
+│   ├── result/
+│   ├── query/
+│   └── brand.ts
+└── README.md                ← Updated with skills install instructions
+```
+
+Two tiers, clearly separated:
+- **`skills/`** — generic, any-project, teaches the wellcrafted API
+- **`.claude/skills/`** — project-specific, teaches wellcrafted's own codebase patterns
+
+## Skill Specifications
+
+### 1. `define-errors` — Defining Error Variants
+
+**Maps to**: `wellcrafted/error`
+
+**Teaches**: `defineErrors`, `extractErrorMessage`, `InferErrors`, `InferError`
+
+**Structure**:
+- Import statement
+- Core rules (all variants in one call, factory returns `{ message, ...fields }`, `cause: unknown` as a field, `extractErrorMessage` inside factory, each call returns `Err<...>`, shadow const with type, variant names describe failure modes)
+- Patterns: zero-arg static message, structured fields with computed message, cause wrapping, multiple variants as discriminated union, single variant type extraction
+- Anti-patterns: one `defineErrors` per variant, `extractErrorMessage` at call site, generic variant names (`Service`, `Error`, `Failed`), discriminated union inputs (string literal sub-discriminants), conditional logic in factories, monolithic catch-all variants
+- Composing errors across layers (service errors become `cause` in higher-level errors)
+
+**Adaptation from internal skill**:
+- Keep: all core rules, all patterns, all anti-patterns (these are already generic)
+- Strip: Whispering-specific examples (`RecorderError`, `DeviceStreamError`, `FfmpegError`)
+- Replace with: generic domains (`HttpError`, `DbError`, `FileError`, `UserError`, `JsonError`)
+- Add: brief "how it connects to Result types" bridge to `result-types` skill
+
+### 2. `result-types` — Working with Results
+
+**Maps to**: `wellcrafted/result`
+
+**Teaches**: `Ok`, `Err`, `trySync`, `tryAsync`, `Result<T, E>`, `isOk`, `isErr`, `unwrap`, `resolve`, `partitionResults`
+
+**Structure**:
+- The `{ data, error }` shape and why (Supabase, SvelteKit familiarity)
+- `Ok()` and `Err()` constructors
+- `trySync` for synchronous operations, `tryAsync` for async
+- Key rules: choose right function, always await tryAsync, match return types, `Ok(undefined)` for void, `Err` for propagation
+- Recovery pattern: `catch` returns `Ok(fallback)` instead of `Err` — narrows to `Ok<T>`
+- Wrapping guidelines: minimal wrap (only the risky operation), immediate return pattern, when to extend the try block
+- The destructured-error gotcha: `{ data, error }` gives raw error, must wrap with `Err()` before returning
+- Utility functions: `isOk`/`isErr` type guards, `unwrap`, `resolve`, `partitionResults`
+
+**Adaptation from internal skill**:
+- Keep: wrapping principles, immediate return pattern, key rules, destructured-error gotcha
+- Strip: Elysia/HTTP handler sections (too framework-specific), Whispering code examples
+- Replace with: generic examples (JSON parsing, file operations, API calls, database queries)
+- Add: `Ok`/`Err` constructor docs, utility function docs, recovery pattern
+
+### 3. `query-factories` — TanStack Query Integration
+
+**Maps to**: `wellcrafted/query`
+
+**Teaches**: `createQueryFactories`, `defineQuery`, `defineMutation`, dual interface (`.options` vs callable)
+
+**Structure**:
+- Setup: `createQueryFactories(queryClient)`
+- `defineQuery` with `queryKey` and `queryFn` returning `Result<T, E>`
+- `defineMutation` with `mutationFn` returning `Result<T, E>`
+- Dual interface: `.options` for reactive frameworks (React/Svelte), `.fetch()`/`.execute()` for imperative use
+- Error transformation at query boundary (service errors → user-facing errors)
+- Query key organization patterns
+- Cache management with optimistic updates
+
+**Adaptation from internal skill**:
+- Keep: dual interface pattern, error transformation, cache management
+- Strip: Whispering-specific RPC namespace, service selection pattern, Svelte-specific syntax
+- Replace with: framework-agnostic examples (show both React and Svelte patterns briefly)
+- Significantly shorter than internal version — focus on the wellcrafted-specific API
+
+### 4. `branded-types` — Type-Safe Distinct Primitives
+
+**Maps to**: `wellcrafted/brand`
+
+**Teaches**: `Brand<T>`, brand constructor pattern
+
+**Structure**:
+- What branded types solve (mixing up `UserId` and `OrderId`)
+- The `Brand<T>` type
+- Brand constructor pattern (PascalCase function matching type name)
+- Why brand constructors over scattered `as` casts
+- When to add runtime validation
+
+**Adaptation from internal skill**:
+- Extracted from `typescript` skill's "Branded Types Pattern" section
+- Keep: brand constructor pattern, naming convention, rationale
+- Strip: arktype-specific brand pipe pattern, workspace table references
+- Add: standalone motivation example, import statement
+
+### 5. `patterns` — Architectural Style Guide
+
+**Maps to**: no single export — cross-cutting patterns for code that uses wellcrafted
+
+**Teaches**: How to structure code that uses wellcrafted idiomatically. Not API reference — architectural taste.
+
+**Structure**:
+- Human-readable control flow: guard clauses with `trySync`/`tryAsync`, early returns, linearizing nested conditionals, natural-language boolean variables
+- Factory function composition: `createX(deps, options?) → { methods }`, the universal signature, separating client/service/method options, zone ordering (immutable state → mutable state → private helpers → public API)
+- Service layer patterns: factory functions returning `Result<T, E>`, `defineErrors` per service domain, export factory + Live instance, namespace re-exports
+- Error composition across layers: service errors as `cause` in higher-level errors, transforming errors at layer boundaries
+- The single-or-array pattern: `T | T[]` input, normalize with `Array.isArray`, one code path
+
+**Adaptation from internal skills**:
+- Merged from: `control-flow`, `factory-function-composition`, `services-layer`, `single-or-array-pattern`
+- Keep: all patterns and anti-patterns (already mostly generic)
+- Strip: all Whispering-specific examples, file paths, Tauri platform detection
+- Replace with: generic service examples (UserService, HttpClient, FileService)
+- Tone: this is a style guide, not API docs — "here's how we think code should look when using wellcrafted"
+## Writing Guidelines for Skills
+
+Each skill follows these principles (from writing-voice):
+
+1. **Lead with the point** — import statement and core rules first, not motivation
+2. **Show mechanism, not marketing** — code patterns, not "defineErrors provides a clean..." prose
+3. **Concrete over abstract** — every rule has a code example
+4. **Anti-patterns are first-class** — agents learn more from "don't do this" than "do this"
+5. **No project-specific references** — every example should work in any TypeScript project
+6. **Cross-reference between skills** — brief "See also: `result-types` skill" bridges
+7. **Minimal prose between code blocks** — the code IS the documentation
+8. **No emojis, no bold-everything, no bullet-list-everything** — natural, direct voice
+
+## Implementation Plan
+
+### Phase 1: Create skill directory and define-errors skill
+
+- [x] **1.1** Create `skills/` directory at repo root
+- [x] **1.2** Write `skills/define-errors/SKILL.md` — adapted from internal skill with generic examples
+- [x] **1.3** Verify `npx skills add . --list` discovers the skill locally
+
+### Phase 2: Create remaining skills
+
+- [x] **2.1** Write `skills/result-types/SKILL.md` — adapted from error-handling skill + new content
+- [x] **2.2** Write `skills/query-factories/SKILL.md` — adapted from query-layer skill
+- [x] **2.3** Write `skills/branded-types/SKILL.md` — extracted from typescript skill
+- [x] **2.4** Write `skills/patterns/SKILL.md` — merged from control-flow, factory-function-composition, services-layer, single-or-array-pattern
+
+### Phase 3: Documentation and testing
+
+- [ ] **3.1** Update README.md with skills installation section
+- [ ] **3.2** Test installation: `npx skills add . --list` shows all 5 skills
+- [ ] **3.3** Test installation: `npx skills add . --skill define-errors -a claude-code -y` works
+
+## Open Questions
+
+1. **Should the skills reference the README or be self-contained?**
+   - Self-contained is better for agents (no need to fetch external docs)
+   - But there's duplication risk with the README
+   - Recommendation: skills are self-contained with all patterns; README provides the high-level story. Skills go deeper on patterns and anti-patterns than the README does.
+
+2. **Versioning strategy for skills vs library?**
+   - Skills content should match the current API
+   - `npx skills update` pulls latest from main branch
+   - Recommendation: no separate versioning — skills live in the same repo and stay in sync naturally
+
+## Success Criteria
+
+- [ ] `npx skills add wellcrafted-dev/wellcrafted --list` shows 5 skills
+- [ ] Each skill has YAML frontmatter with `name` and `description`
+- [ ] No project-specific references (no "Whispering", no "apps/", no "Tauri")
+- [ ] Every rule has a code example
+- [ ] Every anti-pattern has a "wrong" and "right" code block
+- [ ] Import paths use `wellcrafted/error`, `wellcrafted/result`, etc.
+- [ ] README documents the skills installation
+- [ ] Skills are discoverable by agents via description matching
+
+## References
+
+- `.claude/skills/define-errors/SKILL.md` — primary source for define-errors skill
+- `.claude/skills/error-handling/SKILL.md` — primary source for result-types skill
+- `.claude/skills/query-layer/SKILL.md` — primary source for query-factories skill
+- `.claude/skills/typescript/SKILL.md` — branded types section for branded-types skill
+- `.claude/skills/services-layer/SKILL.md` — primary source for patterns skill (service layer section)
+- `.claude/skills/control-flow/SKILL.md` — primary source for patterns skill (control flow section)
+- `.claude/skills/factory-function-composition/SKILL.md` — primary source for patterns skill (factory section)
+- `.claude/skills/single-or-array-pattern/SKILL.md` — primary source for patterns skill (single-or-array section)
+- `README.md` — current API documentation and examples
+- `npx skills --help` — CLI documentation


### PR DESCRIPTION
Adds 5 distributable agent skills in `skills/` so that any project using wellcrafted can teach their AI coding agent how to use it correctly. A developer who `npm install wellcrafted` and then runs `npx skills add wellcrafted-dev/wellcrafted` gets patterns, anti-patterns, and API conventions installed directly into their agent's context.

The library had 20 internal skills in `.claude/skills/` that taught agents how to use wellcrafted — but they were locked to this repo, full of Whispering-specific references (RecorderError, DeviceStreamError, FfmpegError, Tauri platform detection). A developer's agent had no idea how to use defineErrors, would guess at patterns, produce `as any` casts, and create class-based errors instead of variant factories. These 5 skills fix that.

```bash
# What a wellcrafted user runs
npx skills add wellcrafted-dev/wellcrafted
```

```
wellcrafted/
├── .claude/skills/          ← Internal: for contributing to wellcrafted
│   └── ... (20 skills)
│
├── skills/                  ← Distributable: for USERS of wellcrafted
│   ├── define-errors/       defineErrors variants, extractErrorMessage, InferErrors
│   ├── result-types/        Ok, Err, trySync/tryAsync, { data, error } destructuring
│   ├── query-factories/     createQueryFactories, defineQuery/defineMutation, dual interface
│   ├── branded-types/       Brand<T>, brand constructor pattern
│   └── patterns/            Style guide: control flow, factory composition, service layers
│
└── src/                     ← Library source (unchanged)
```

### How each skill was built

Every skill was adapted from internal `.claude/skills/` sources. The adaptation rule was strict: every project-specific reference gets replaced with a generic domain, every import path uses `wellcrafted/*`, every anti-pattern gets a WRONG/CORRECT code block.

| Skill | Lines | Adapted from | Key change |
| --- | --- | --- | --- |
| `define-errors` | 272 | `.claude/skills/define-errors/` | RecorderError → UserError, FfmpegError → FileError |
| `result-types` | 264 | `.claude/skills/error-handling/` | Stripped Elysia/handler sections, added utility function docs |
| `query-factories` | 197 | `.claude/skills/query-layer/` | Stripped Whispering RPC namespace, shows React + Svelte |
| `branded-types` | 131 | `.claude/skills/typescript/` branded section | Stripped arktype pipe patterns, standalone focus |
| `patterns` | 361 | Merged from 4 skills: control-flow, factory-function-composition, services-layer, single-or-array-pattern | All Whispering services → generic UserService/HttpClient |

Verified clean with `grep -ri "whispering\|RecorderError\|DeviceStream\|FfmpegError\|Tauri\|Elysia" skills/` — zero hits.

### What else changed

**README.md** gets a new "AI Agent Skills" section before "Development Setup" — tells library users how to install skills. The existing EpicenterHQ section for contributors stays untouched.

**AGENTS.md** updated to document the two-tier skill system: `skills/` for library users, `.claude/skills/` for contributors.

**Spec** at `specs/20260311T124200-distributable-agent-skills.md` — all items checked off, review section added. Committed alongside code so the git history shows what was planned vs. what was built.

### Why this structure

`npx skills` discovers SKILL.md files in `skills/` at repo root — no registry, no approval process, just push to GitHub. The tool scans multiple directories (skills/, root, curated/skills/, agent-specific dirs), so both `skills/` and `.claude/skills/` are found. A user running `npx skills add wellcrafted-dev/wellcrafted` sees all 5 distributable skills and can pick which ones to install.

The skills intentionally do NOT go in the npm package (not in `files` array). They're distributed via GitHub because `npx skills` pulls from repos, not npm. This means updating a skill is just a push to main — no version bump needed.

### Why the skills are self-contained

Each skill is a standalone document with all patterns and anti-patterns inline. The alternative was linking back to README.md, but that means the agent would need to fetch external docs at runtime. Self-contained skills load instantly and work offline. There's some content overlap with the README, but the skills go deeper on patterns and anti-patterns than the README does — the README tells the high-level story, skills teach the detailed craft.