### PR TITLE
feat: add parseJson and the wellcrafted/testing entry point

### DIFF
--- a/.changeset/add-parse-json.md
+++ b/.changeset/add-parse-json.md
@@ -1,0 +1,20 @@
+---
+"wellcrafted": minor
+---
+
+Add `parseJson` and `JsonParseError` to `wellcrafted/json`.
+
+`parseJson(text)` parses a JSON string into a `Result<JsonValue, JsonParseError>` instead of throwing. It is the Result-returning counterpart to `JSON.parse`:
+
+- the success value is typed as `JsonValue` rather than `any`, so you must narrow or validate it before treating it as a known shape
+- malformed input is reported as a tagged `JsonParseError` (built with `defineErrors`) carrying the underlying `SyntaxError` as `cause`, instead of throwing
+
+```ts
+import { parseJson } from "wellcrafted/json";
+
+const { data, error } = parseJson(raw);
+if (error) return Err(error); // JsonParseError
+data; // JsonValue
+```
+
+No reviver argument is accepted: a reviver can return arbitrary values, which would make the `JsonValue` success type unsound.

--- a/.changeset/add-testing-helpers.md
+++ b/.changeset/add-testing-helpers.md
@@ -1,0 +1,17 @@
+---
+"wellcrafted": minor
+---
+
+Add the `wellcrafted/testing` entry point with `expectOk` and `expectErr`.
+
+These are test-only assertion helpers for `Result` values. Each unwraps the expected branch and returns it narrowed, throwing if the `Result` is the other variant:
+
+```ts
+import { expectOk, expectErr } from "wellcrafted/testing";
+
+const value = expectOk(parseConfig(raw));   // success value, narrowed
+const error = expectErr(parseConfig("x"));  // error value, narrowed
+expect(error.name).toBe("ConfigParseError");
+```
+
+They intentionally throw: a failed expectation should abort the test, which every runner reports as a failure. Throwing is fenced into this separate `wellcrafted/testing` entry point so `wellcrafted/result` stays throw-free. The helpers throw a plain `Error`, so they work under bun, vitest, jest, or `node:test` without depending on a test framework.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,10 @@
 		"./standard-schema": {
 			"types": "./dist/standard-schema/index.d.ts",
 			"import": "./dist/standard-schema/index.js"
+		},
+		"./testing": {
+			"types": "./dist/testing.d.ts",
+			"import": "./dist/testing.js"
 		}
 	},
 	"scripts": {

--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, expectTypeOf, it } from "bun:test";
 import { type JsonValue, parseJson } from "./json.js";
+import { expectErr, expectOk } from "./testing.js";
 
 describe("parseJson", () => {
 	// =============================================================================
@@ -7,22 +8,26 @@ describe("parseJson", () => {
 	// =============================================================================
 
 	it("parses an object", () => {
-		const { data, error } = parseJson('{"count":1,"ok":true}');
-		expect(error).toBeNull();
-		expect(data).toEqual({ count: 1, ok: true });
+		expect(expectOk(parseJson('{"count":1,"ok":true}'))).toEqual({
+			count: 1,
+			ok: true,
+		});
 	});
 
 	it("parses an array", () => {
-		const { data, error } = parseJson('[1,"two",false,null]');
-		expect(error).toBeNull();
-		expect(data).toEqual([1, "two", false, null]);
+		expect(expectOk(parseJson('[1,"two",false,null]'))).toEqual([
+			1,
+			"two",
+			false,
+			null,
+		]);
 	});
 
 	it("parses primitives", () => {
-		expect(parseJson('"hello"').data).toBe("hello");
-		expect(parseJson("42").data).toBe(42);
-		expect(parseJson("true").data).toBe(true);
-		expect(parseJson("null").data).toBeNull();
+		expect(expectOk(parseJson('"hello"'))).toBe("hello");
+		expect(expectOk(parseJson("42"))).toBe(42);
+		expect(expectOk(parseJson("true"))).toBe(true);
+		expect(expectOk(parseJson("null"))).toBeNull();
 	});
 
 	// =============================================================================
@@ -30,20 +35,17 @@ describe("parseJson", () => {
 	// =============================================================================
 
 	it("returns Err for malformed input", () => {
-		const { data, error } = parseJson("{ not json");
-		expect(data).toBeNull();
-		expect(error).not.toBeNull();
-		expect(error?.name).toBe("JsonParseError");
-		expect(error?.message).toStartWith("Failed to parse JSON: ");
+		const error = expectErr(parseJson("{ not json"));
+		expect(error.name).toBe("JsonParseError");
+		expect(error.message).toStartWith("Failed to parse JSON: ");
 	});
 
 	it("returns Err for an empty string", () => {
-		expect(parseJson("").error?.name).toBe("JsonParseError");
+		expect(expectErr(parseJson("")).name).toBe("JsonParseError");
 	});
 
 	it("preserves the underlying SyntaxError as cause", () => {
-		const { error } = parseJson("{");
-		expect(error?.cause).toBeInstanceOf(SyntaxError);
+		expect(expectErr(parseJson("{")).cause).toBeInstanceOf(SyntaxError);
 	});
 
 	// =============================================================================
@@ -51,9 +53,6 @@ describe("parseJson", () => {
 	// =============================================================================
 
 	it("types the success value as JsonValue", () => {
-		const { data, error } = parseJson("{}");
-		if (!error) {
-			expectTypeOf(data).toEqualTypeOf<JsonValue>();
-		}
+		expectTypeOf(expectOk(parseJson("{}"))).toEqualTypeOf<JsonValue>();
 	});
 });

--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, expectTypeOf, it } from "bun:test";
+import { type JsonValue, parseJson } from "./json.js";
+
+describe("parseJson", () => {
+	// =============================================================================
+	// Success: every JSON value kind round-trips
+	// =============================================================================
+
+	it("parses an object", () => {
+		const { data, error } = parseJson('{"count":1,"ok":true}');
+		expect(error).toBeNull();
+		expect(data).toEqual({ count: 1, ok: true });
+	});
+
+	it("parses an array", () => {
+		const { data, error } = parseJson('[1,"two",false,null]');
+		expect(error).toBeNull();
+		expect(data).toEqual([1, "two", false, null]);
+	});
+
+	it("parses primitives", () => {
+		expect(parseJson('"hello"').data).toBe("hello");
+		expect(parseJson("42").data).toBe(42);
+		expect(parseJson("true").data).toBe(true);
+		expect(parseJson("null").data).toBeNull();
+	});
+
+	// =============================================================================
+	// Failure: malformed input produces a tagged JsonParseError
+	// =============================================================================
+
+	it("returns Err for malformed input", () => {
+		const { data, error } = parseJson("{ not json");
+		expect(data).toBeNull();
+		expect(error).not.toBeNull();
+		expect(error?.name).toBe("JsonParseError");
+		expect(error?.message).toStartWith("Failed to parse JSON: ");
+	});
+
+	it("returns Err for an empty string", () => {
+		expect(parseJson("").error?.name).toBe("JsonParseError");
+	});
+
+	it("preserves the underlying SyntaxError as cause", () => {
+		const { error } = parseJson("{");
+		expect(error?.cause).toBeInstanceOf(SyntaxError);
+	});
+
+	// =============================================================================
+	// Types: success value is JsonValue, never `any`
+	// =============================================================================
+
+	it("types the success value as JsonValue", () => {
+		const { data, error } = parseJson("{}");
+		if (!error) {
+			expectTypeOf(data).toEqualTypeOf<JsonValue>();
+		}
+	});
+});

--- a/src/json.ts
+++ b/src/json.ts
@@ -1,3 +1,10 @@
+import {
+	defineErrors,
+	extractErrorMessage,
+	type InferError,
+} from "./error/index.js";
+import { type Result, trySync } from "./result/index.js";
+
 /**
  * JSON-serializable value types.
  * Ensures data can be safely serialized via JSON.stringify.
@@ -23,3 +30,62 @@ export type JsonValue =
  * A record where every value is a {@link JsonValue}.
  */
 export type JsonObject = Record<string, JsonValue>;
+
+// =============================================================================
+// Parsing
+// =============================================================================
+
+/**
+ * Constructs a {@link JsonParseError}. Returns `Err<JsonParseError>` directly,
+ * ready to return from a `trySync`/`tryAsync` catch handler.
+ */
+export const { JsonParseError } = defineErrors({
+	JsonParseError: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to parse JSON: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+});
+
+/**
+ * The error {@link parseJson} produces when its input is not valid JSON.
+ *
+ * JSON parsing has exactly one failure mode (the engine throws a `SyntaxError`),
+ * so this is a single variant. A valid-JSON-but-wrong-shape value is not a
+ * parse failure: validate the returned {@link JsonValue} against a schema for
+ * that case.
+ */
+export type JsonParseError = InferError<typeof JsonParseError>;
+
+/**
+ * Parses a JSON string into a {@link JsonValue}, returning a `Result` instead
+ * of throwing.
+ *
+ * Unlike `JSON.parse`, which returns `any` and throws on malformed input, this:
+ * - types the success value as {@link JsonValue}, forcing you to narrow or
+ *   validate before treating it as a known shape
+ * - reports failure as a tagged {@link JsonParseError} rather than an exception
+ *
+ * No reviver argument is accepted. A reviver can return arbitrary values, which
+ * would make the {@link JsonValue} success type a lie.
+ *
+ * @param text - The JSON string to parse.
+ * @returns `Ok<JsonValue>` on success, `Err<JsonParseError>` on malformed input.
+ *
+ * @example
+ * ```ts
+ * import { parseJson } from "wellcrafted/json";
+ *
+ * const { data, error } = parseJson('{"count":1}');
+ * if (error) {
+ *   console.error(error.message); // "Failed to parse JSON: ..."
+ * } else {
+ *   data; // JsonValue — narrow or validate before using
+ * }
+ * ```
+ */
+export function parseJson(text: string): Result<JsonValue, JsonParseError> {
+	return trySync({
+		try: () => JSON.parse(text) as JsonValue,
+		catch: (cause) => JsonParseError({ cause }),
+	});
+}

--- a/src/testing.test.ts
+++ b/src/testing.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, expectTypeOf, it } from "bun:test";
+import { Err, Ok } from "./result/index.js";
+import { expectErr, expectOk } from "./testing.js";
+
+describe("expectOk", () => {
+	it("returns data when the Result is Ok", () => {
+		expect(expectOk(Ok(42))).toBe(42);
+	});
+
+	it("throws when the Result is Err", () => {
+		expect(() => expectOk(Err("boom"))).toThrow(
+			"Expected Ok, but got Err: boom",
+		);
+	});
+
+	it("narrows the return value to the success type", () => {
+		expectTypeOf(expectOk(Ok("hello"))).toEqualTypeOf<string>();
+	});
+});
+
+describe("expectErr", () => {
+	it("returns the error when the Result is Err", () => {
+		expect(expectErr(Err("boom"))).toBe("boom");
+	});
+
+	it("throws when the Result is Ok", () => {
+		expect(() => expectErr(Ok(42))).toThrow("Expected Err, but got Ok");
+	});
+
+	it("narrows the return value to the error type", () => {
+		expectTypeOf(expectErr(Err({ name: "X" as const }))).toEqualTypeOf<{
+			name: "X";
+		}>();
+	});
+});

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -1,0 +1,60 @@
+import { extractErrorMessage } from "./error/index.js";
+import { isErr, isOk, type Result } from "./result/index.js";
+
+/**
+ * Test-only assertion helpers for `Result` values.
+ *
+ * These helpers intentionally **throw**. A failed expectation should abort the
+ * test, and every test runner reports a thrown error as a failure. Tests are
+ * the one place throwing is the correct control flow, so these are fenced into
+ * the `wellcrafted/testing` entry point and kept out of `wellcrafted/result`,
+ * which stays throw-free. Importing from `wellcrafted/testing` in production
+ * code is a smell worth linting against.
+ *
+ * They are framework-agnostic: they throw a plain `Error` rather than calling
+ * into a specific runner, so they work under bun, vitest, jest, or
+ * `node:test`.
+ */
+
+/**
+ * Asserts that `result` is `Ok` and returns its `data`.
+ *
+ * Throws if `result` is `Err`. The returned value is narrowed to the success
+ * type, so no optional chaining or casting is needed at the call site.
+ *
+ * @example
+ * ```ts
+ * import { expectOk } from "wellcrafted/testing";
+ *
+ * const value = expectOk(parseConfig(raw)); // typed as the success value
+ * ```
+ */
+export function expectOk<T>(result: Result<T, unknown>): T {
+	if (!isOk(result)) {
+		throw new Error(
+			`Expected Ok, but got Err: ${extractErrorMessage(result.error)}`,
+		);
+	}
+	return result.data;
+}
+
+/**
+ * Asserts that `result` is `Err` and returns its `error`.
+ *
+ * Throws if `result` is `Ok`. The returned value is narrowed to the error
+ * type, so no optional chaining or casting is needed at the call site.
+ *
+ * @example
+ * ```ts
+ * import { expectErr } from "wellcrafted/testing";
+ *
+ * const error = expectErr(parseConfig("not valid"));
+ * expect(error.name).toBe("ConfigParseError");
+ * ```
+ */
+export function expectErr<E>(result: Result<unknown, E>): E {
+	if (!isErr(result)) {
+		throw new Error("Expected Err, but got Ok");
+	}
+	return result.error;
+}

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
 		"src/brand.ts",
 		"src/query/index.ts",
 		"src/standard-schema/index.ts",
+		"src/testing.ts",
 	],
 	format: ["esm"],
 	target: "esnext",


### PR DESCRIPTION
`wellcrafted/json` has shipped the `JsonValue` and `JsonObject` types for a while, but never anything that runs. So the moment you actually need to parse JSON, you drop back to `JSON.parse`, and `JSON.parse` has two rough edges that have been there since forever: it returns `any`, and it throws. The `any` lets parsed data flow untyped through the rest of your code, with nothing stopping you from reading a field that was never there. The throw means every careful call site ends up hand-rolling a `try/catch` or an inline `trySync`.

`parseJson` is the runtime that closes both:

```ts
import { parseJson } from "wellcrafted/json";

const { data, error } = parseJson(raw);
if (error) return Err(error); // JsonParseError, with the SyntaxError kept as cause
data;                         // JsonValue, not any
```

The success value is typed `JsonValue`, so you have to narrow or validate it before treating it as a known shape. Failure comes back as a tagged `JsonParseError`, built with `defineErrors`, carrying the underlying `SyntaxError` as `cause`.

There is exactly one error variant, and that is on purpose. `JSON.parse` only ever fails for one reason: the input is not valid JSON. A string that parses fine but is not the shape you expected is not a parse failure, it is a validation failure, and that belongs a layer up with a schema. `parseJson` also takes no reviver argument, since a reviver can return anything at all, which would quietly turn the `JsonValue` success type into a lie.

Writing the tests for `parseJson` is what surfaced the rest of this PR. A test for the failure path wants to assert the Result is an `Err` and then read `error.name`. After a plain destructure, TypeScript still thinks `error` might be null, since it cannot see that the preceding `expect` already ruled that out, so you reach for optional chaining. That is the wrong tool, and it pushed the helpers in `wellcrafted/testing`:

```ts
import { expectOk, expectErr } from "wellcrafted/testing";

const value = expectOk(parseJson(raw));      // success value, narrowed
const error = expectErr(parseJson("nope"));  // error value, narrowed
expect(error.name).toBe("JsonParseError");
```

Each helper asserts one branch and returns the narrowed value, throwing if the Result turns out to be the other variant.

They throw on purpose. A failed expectation should abort the test, and every runner reports a thrown error as a failure, so a test is the one place throwing is the correct control flow. That is why they sit behind a separate `wellcrafted/testing` import instead of in `wellcrafted/result`: the core stays throw-free, and an `import ... from "wellcrafted/testing"` in production code is an obvious smell you can lint against. The helpers throw a plain `Error` rather than calling into a test framework, so they behave the same under bun, vitest, jest, or `node:test`.

Two commits, two changesets, both minor. `json.test.ts` uses the new helpers itself, so the testing module gets exercised the moment it lands.