### PR TITLE
feat(error): add defineHttpErrors

### DIFF
--- a/.changeset/define-http-errors.md
+++ b/.changeset/define-http-errors.md
@@ -1,0 +1,22 @@
+---
+"wellcrafted": minor
+---
+
+Add `defineHttpErrors`: typed HTTP error factories with a static `.status` property.
+
+Like `defineErrors`, but each variant is paired with its HTTP status code via a `[status, factory]` tuple. The status is attached to the factory function as a literal type (e.g. `AssetError.MissingFile.status` is `400`), never serialized into the error body.
+
+```ts
+const AssetError = defineHttpErrors({
+  MissingFile:          [400, () => ({ message: 'Missing file' })],
+  FileTooLarge:         [413, ({ size }: { size: number }) => ({ message: `File too large: ${size}`, size })],
+  StorageLimitExceeded: [402, () => ({ message: 'Storage limit exceeded' })],
+});
+
+// Hono route handler:
+return c.json(AssetError.MissingFile(), AssetError.MissingFile.status);
+// body:   { error: { name: 'MissingFile', message: 'Missing file' }, data: null }
+// status: 400
+```
+
+Also exports `InferHttpError`, `InferHttpErrors`, `HttpErrorFactory`, `DefineHttpErrorsReturn`, `HttpErrorsConfig`, and `ValidatedHttpConfig`.

--- a/src/error/defineHttpErrors.test.ts
+++ b/src/error/defineHttpErrors.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, expectTypeOf } from "bun:test";
+import { defineHttpErrors } from "./defineHttpErrors.js";
+import type { InferHttpError, InferHttpErrors } from "./defineHttpErrors.js";
+import type { Err } from "../result/result.js";
+
+// =============================================================================
+// Basic factories
+// =============================================================================
+
+describe("defineHttpErrors - basic factories", () => {
+	const AssetError = defineHttpErrors({
+		MissingFile: [400, () => ({ message: "Missing file" })],
+		NotFound: [404, () => ({ message: "Asset not found" })],
+	});
+
+	it("stamps name on the error", () => {
+		const result = AssetError.MissingFile();
+		expect(result.error.name).toBe("MissingFile");
+	});
+
+	it("preserves message", () => {
+		const result = AssetError.MissingFile();
+		expect(result.error.message).toBe("Missing file");
+	});
+
+	it("wraps in Err shape", () => {
+		const result = AssetError.MissingFile();
+		expect(result.data).toBeNull();
+	});
+
+	it("attaches literal status to factory", () => {
+		expect(AssetError.MissingFile.status).toBe(400);
+		expect(AssetError.NotFound.status).toBe(404);
+	});
+
+	it("status is not in the error body", () => {
+		const result = AssetError.MissingFile();
+		expect("status" in result.error).toBe(false);
+	});
+});
+
+// =============================================================================
+// Factories with fields
+// =============================================================================
+
+describe("defineHttpErrors - factories with fields", () => {
+	const AssetError = defineHttpErrors({
+		FileTooLarge: [413, ({ size }: { size: number }) => ({
+			message: `File too large: ${size}`,
+			size,
+		})],
+		FileTypeNotAllowed: [415, ({ contentType }: { contentType: string }) => ({
+			message: `File type not allowed: ${contentType}`,
+			contentType,
+		})],
+	});
+
+	it("forwards fields to the error body", () => {
+		const result = AssetError.FileTooLarge({ size: 1024 });
+		expect(result.error.size).toBe(1024);
+		expect(result.error.message).toBe("File too large: 1024");
+	});
+
+	it("status is correct literal on factory with args", () => {
+		expect(AssetError.FileTooLarge.status).toBe(413);
+		expect(AssetError.FileTypeNotAllowed.status).toBe(415);
+	});
+
+	it("status is not in the error body even when fields are present", () => {
+		const result = AssetError.FileTooLarge({ size: 2048 });
+		expect("status" in result.error).toBe(false);
+	});
+});
+
+// =============================================================================
+// Error body is frozen
+// =============================================================================
+
+describe("defineHttpErrors - immutability", () => {
+	it("error body is frozen", () => {
+		const E = defineHttpErrors({
+			Fail: [500, () => ({ message: "fail" })],
+		});
+		const result = E.Fail();
+		expect(Object.isFrozen(result.error)).toBe(true);
+	});
+});
+
+// =============================================================================
+// Types
+// =============================================================================
+
+describe("defineHttpErrors - types", () => {
+	const AssetError = defineHttpErrors({
+		MissingFile: [400, () => ({ message: "Missing file" })],
+		FileTooLarge: [413, ({ size }: { size: number }) => ({
+			message: `File too large: ${size}`,
+			size,
+		})],
+	});
+
+	it("factory return is Err with correct shape", () => {
+		const result = AssetError.MissingFile();
+		expectTypeOf(result).toEqualTypeOf<
+			Err<Readonly<{ name: "MissingFile"; message: string }>>
+		>();
+	});
+
+	it("factory with fields has correct shape", () => {
+		const result = AssetError.FileTooLarge({ size: 1 });
+		expectTypeOf(result).toEqualTypeOf<
+			Err<Readonly<{ name: "FileTooLarge"; message: string; size: number }>>
+		>();
+	});
+
+	it("status is a literal type on the factory", () => {
+		expectTypeOf(AssetError.MissingFile.status).toEqualTypeOf<400>();
+		expectTypeOf(AssetError.FileTooLarge.status).toEqualTypeOf<413>();
+	});
+
+	it("InferHttpError extracts single error type", () => {
+		type MissingFileError = InferHttpError<typeof AssetError.MissingFile>;
+		expectTypeOf<MissingFileError>().toEqualTypeOf<
+			Readonly<{ name: "MissingFile"; message: string }>
+		>();
+	});
+
+	it("InferHttpErrors extracts union of all error types", () => {
+		type AnyAssetError = InferHttpErrors<typeof AssetError>;
+		const result = AssetError.MissingFile();
+		const err: AnyAssetError = result.error;
+		expect(err.name).toBe("MissingFile");
+	});
+});
+
+// =============================================================================
+// Reserved key — `name`
+// =============================================================================
+
+describe("defineHttpErrors - reserved keys", () => {
+	it("forbids `name` in the variant body", () => {
+		defineHttpErrors({
+			// @ts-expect-error — 'name' is reserved
+			Bad: [400, () => ({ message: "x", name: "overwritten" as const })],
+		});
+	});
+});
+
+// =============================================================================
+// Multiple variants
+// =============================================================================
+
+describe("defineHttpErrors - multiple variants", () => {
+	const ApiError = defineHttpErrors({
+		Unauthorized:    [401, () => ({ message: "Unauthorized" })],
+		Forbidden:       [403, () => ({ message: "Forbidden" })],
+		NotFound:        [404, () => ({ message: "Not found" })],
+		TooManyRequests: [429, () => ({ message: "Too many requests" })],
+		Internal:        [500, () => ({ message: "Internal server error" })],
+	});
+
+	it("each variant has its own status literal", () => {
+		expect(ApiError.Unauthorized.status).toBe(401);
+		expect(ApiError.Forbidden.status).toBe(403);
+		expect(ApiError.NotFound.status).toBe(404);
+		expect(ApiError.TooManyRequests.status).toBe(429);
+		expect(ApiError.Internal.status).toBe(500);
+	});
+
+	it("each variant stamps the correct name", () => {
+		expect(ApiError.Unauthorized().error.name).toBe("Unauthorized");
+		expect(ApiError.Forbidden().error.name).toBe("Forbidden");
+		expect(ApiError.NotFound().error.name).toBe("NotFound");
+	});
+
+	it("status is not in any error body", () => {
+		for (const key of ["Unauthorized", "Forbidden", "NotFound", "TooManyRequests", "Internal"] as const) {
+			expect("status" in ApiError[key]().error).toBe(false);
+		}
+	});
+});

--- a/src/error/defineHttpErrors.ts
+++ b/src/error/defineHttpErrors.ts
@@ -1,0 +1,111 @@
+import { Err } from "../result/result.js";
+import type { ErrorBody } from "./types.js";
+
+// =============================================================================
+// Config types
+// =============================================================================
+
+/** Config: each key maps to `[httpStatus, factory]`. */
+// biome-ignore lint/suspicious/noExplicitAny: required for TypeScript's function type inference
+export type HttpErrorsConfig = Record<string, [number, (...args: any[]) => ErrorBody]>;
+
+/**
+ * Per-key validation applied to the factory portion of each tuple.
+ * Mirrors `ValidatedConfig` from `defineErrors`: prevents `name` in the
+ * factory return body since the factory key is stamped as `name`.
+ */
+type ValidateHttpErrorBody<K extends string> = {
+	message: string;
+	name?: `The 'name' key is reserved as '${K}'. Remove it.`;
+};
+
+export type ValidatedHttpConfig<T extends HttpErrorsConfig> = {
+	// biome-ignore lint/suspicious/noExplicitAny: required for TypeScript's function type inference
+	[K in keyof T & string]: T[K] extends [infer TStatus, (...args: infer A) => infer R]
+		? [TStatus, (...args: A) => R & ValidateHttpErrorBody<K>]
+		: T[K];
+};
+
+// =============================================================================
+// Return types
+// =============================================================================
+
+/**
+ * A factory function with a static `.status` property holding the literal
+ * HTTP status code. The status is never included in the serialized error body.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: required for TypeScript's function type inference
+export type HttpErrorFactory<TName extends string, TStatus extends number, TFn extends (...args: any[]) => ErrorBody> =
+	((...args: Parameters<TFn>) => Err<Readonly<{ name: TName } & ReturnType<TFn>>>) & {
+		readonly status: TStatus;
+	};
+
+/** Return type of `defineHttpErrors`. Maps each config key to its `HttpErrorFactory`. */
+export type DefineHttpErrorsReturn<TConfig extends HttpErrorsConfig> = {
+	// biome-ignore lint/suspicious/noExplicitAny: required for conditional type inference
+	[K in keyof TConfig & string]: TConfig[K] extends [infer TStatus extends number, infer TFn extends (...args: any[]) => ErrorBody]
+		? HttpErrorFactory<K, TStatus, TFn>
+		: never;
+};
+
+// =============================================================================
+// Type utilities
+// =============================================================================
+
+/** Extract the error instance type from a single `HttpErrorFactory`. */
+// biome-ignore lint/suspicious/noExplicitAny: required for conditional type inference
+export type InferHttpError<T> = T extends (...args: any[]) => Err<infer R> ? R : never;
+
+/** Extract the union of all error instance types from a `defineHttpErrors` return. */
+export type InferHttpErrors<T> = {
+	// biome-ignore lint/suspicious/noExplicitAny: required for conditional type inference
+	[K in keyof T]: T[K] extends (...args: any[]) => Err<infer R> ? R : never;
+}[keyof T];
+
+// =============================================================================
+// Implementation
+// =============================================================================
+
+/**
+ * Defines a set of typed HTTP error factories, each paired with its HTTP
+ * status code.
+ *
+ * Like `defineErrors`, each factory stamps `name` onto the error and wraps it
+ * in `Err`. Unlike `defineErrors`, each factory function carries a static
+ * `.status` property with the literal HTTP status code — the status is never
+ * included in the serialized error body.
+ *
+ * @example
+ * ```ts
+ * const AssetError = defineHttpErrors({
+ *   MissingFile:          [400, () => ({ message: 'Missing file' })],
+ *   FileTooLarge:         [413, ({ size }: { size: number }) => ({ message: `File too large: ${size}`, size })],
+ *   StorageLimitExceeded: [402, () => ({ message: 'Storage limit exceeded' })],
+ * });
+ *
+ * type AssetError = InferHttpErrors<typeof AssetError>;
+ *
+ * // In a Hono route handler:
+ * return c.json(AssetError.MissingFile(), AssetError.MissingFile.status);
+ * // wire body: { error: { name: 'MissingFile', message: 'Missing file' }, data: null }
+ * // http status: 400
+ * ```
+ */
+export function defineHttpErrors<const TConfig extends HttpErrorsConfig>(
+	config: TConfig & ValidatedHttpConfig<TConfig>,
+): DefineHttpErrorsReturn<TConfig> {
+	const result: Record<string, unknown> = {};
+
+	for (const [name, [status, factory]] of Object.entries(config)) {
+		const fn = (...args: unknown[]) => {
+			const body = (factory as (...a: unknown[]) => Record<string, unknown>)(
+				...args,
+			);
+			return Err(Object.freeze({ ...body, name }));
+		};
+		(fn as unknown as { status: number }).status = status;
+		result[name] = fn;
+	}
+
+	return result as unknown as DefineHttpErrorsReturn<TConfig>;
+}

--- a/src/error/index.ts
+++ b/src/error/index.ts
@@ -1,3 +1,12 @@
 export * from "./types.js";
 export { defineErrors } from "./defineErrors.js";
+export {
+	defineHttpErrors,
+	type HttpErrorsConfig,
+	type ValidatedHttpConfig,
+	type HttpErrorFactory,
+	type DefineHttpErrorsReturn,
+	type InferHttpError,
+	type InferHttpErrors,
+} from "./defineHttpErrors.js";
 export { extractErrorMessage } from "./extractErrorMessage.js";

--- a/src/logger/console-sink.ts
+++ b/src/logger/console-sink.ts
@@ -18,6 +18,18 @@ import type { LogSink } from "./types.js";
  * annotation form would widen an unnecessary Partial into the value type.
  *
  * No dispose handler — `console` is not a resource.
+ *
+ * ### CLI authors: stream routing
+ *
+ * `console[level]` routes by level, not uniformly to stdout:
+ * - `console.log` (not used here) is the only method that writes stdout.
+ * - `console.info`, `console.debug`, `console.warn`, `console.error`,
+ *   `console.trace` all write **stderr** in Node/Bun.
+ *
+ * For a CLI that emits structured program output on stdout and diagnostics
+ * on stderr, this default is correct — every logger event goes to stderr.
+ * Authors who expect `log.info` to print to stdout will be surprised; write
+ * a custom sink that routes to `process.stdout` if that's the requirement.
  */
 export const consoleSink = ((event) => {
 	const prefix = `[${event.source}]`;

--- a/src/logger/create-logger.ts
+++ b/src/logger/create-logger.ts
@@ -25,16 +25,38 @@ function unwrapLoggable(err: LoggableError): AnyTaggedError {
  *   plus the level string); spelling them out beats an `emitErr("warn")`
  *   riddle.
  *
+ * ### Source convention
+ *
+ * `source` is a free-form string, but downstream filtering and tail-log
+ * grep become much easier when call sites converge on a shape. Recommended:
+ *
+ *     '<package>/<module>'    e.g. 'workspace/sync-supervisor'
+ *     '<app>/<feature>'       e.g. 'fuji/daemon-route'
+ *     '<package>/<area>'      e.g. 'auth/oauth-app'
+ *
+ * Keep it lowercase-kebab. Avoid bare factory names like
+ * `'attachSqliteMaterializer'`: they don't carry package context.
+ *
+ * ### Module-scope vs injected
+ *
+ * `const log = createLogger('source')` at module scope is fine for
+ * process-singleton modules (CLI commands, app bootstrap, leaf utilities
+ * the host does not customize per instance). For anything that can be
+ * instantiated more than once per process with different routing needs
+ * (per-document attach primitives, per-account auth state, per-workspace
+ * services), accept `log?: Logger` at the factory boundary and default
+ * to `createLogger('source')` for development ergonomics.
+ *
  * @example Library code (caller wires the sink)
  * function attachThing(ydoc: Doc, opts: { log?: Logger }) {
- *   const log = opts.log ?? createLogger('thing');
+ *   const log = opts.log ?? createLogger('workspace/thing');
  *   // ...
  * }
  *
  * @example App wiring (share one sink, multiple loggers)
  * const sink = composeSinks(consoleSink, myCustomSink);
- * attachThing(ydoc, { log: createLogger('thing', sink) });
- * attachOther(ydoc, { log: createLogger('other', sink) });
+ * attachThing(ydoc, { log: createLogger('workspace/thing', sink) });
+ * attachOther(ydoc, { log: createLogger('workspace/other', sink) });
  */
 export function createLogger(
 	source: string,


### PR DESCRIPTION
HTTP APIs need two things from an error factory: a typed error body and the status code that should travel with it. `defineErrors` already handled the body shape well, but every route still had to keep status codes in some nearby hand-written map or inline constant. That works until the map drifts, a route uses the wrong status, or the type system forgets that this particular error is always a `400`.

`defineHttpErrors` keeps those two pieces next to each other without putting transport metadata into the serialized error:

```ts
const AssetError = defineHttpErrors({
  MissingFile: [400, () => ({ message: "Missing file" })],
  FileTooLarge: [
    413,
    ({ size }: { size: number }) => ({
      message: `File too large: ${size}`,
      size,
    }),
  ],
  StorageLimitExceeded: [402, () => ({ message: "Storage limit exceeded" })],
});

return c.json(AssetError.MissingFile(), AssetError.MissingFile.status);
```

The factory still returns the same tagged error body shape reviewers already know from `defineErrors`. The status lives on the factory function as a literal type:

```txt
AssetError.MissingFile()
  └── { name: "MissingFile", message: "Missing file" }

AssetError.MissingFile.status
  └── 400, typed as 400 instead of number
```

That split is the important design choice. The response body stays portable and name-discriminated; the HTTP-only piece is attached at the call site where the transport actually needs it.

```txt
defineHttpErrors({
  MissingFile: [400, factory],
                 │      │
                 │      └── builds the serialized error body
                 └───────── stays on the factory as .status
})
```

The tuple shape is status-first on purpose. In a long API error list, reviewers can scan the transport behavior without reading every factory implementation:

```txt
MissingFile           400
FileTooLarge          413
StorageLimitExceeded  402
```

This also ships `InferHttpError` and `InferHttpErrors`, plus the same reserved `name` guard as `defineErrors`, so a variant factory cannot accidentally overwrite the discriminator.

The PR also tightens logger documentation that came up while working through API ergonomics: source strings should follow the `<package>/<module>` convention, module-scope loggers are fine for singletons, injected `log?: Logger` is the right shape for multi-instance modules, and `consoleSink` routes `info`, `warn`, and `error` through the matching `console` methods rather than promising stdout.

Validation:

```txt
defineHttpErrors.test.ts
  ├── runtime factory behavior
  ├── literal .status types
  ├── immutability
  ├── reserved name guard
  └── multi-variant status correctness

Full suite: 146 tests passing
Typecheck: clean
Changeset: minor
```
