### PR TITLE
feat(query): infer literal queryKey tuples without `as const`

### DIFF
--- a/.changeset/const-query-key.md
+++ b/.changeset/const-query-key.md
@@ -1,0 +1,23 @@
+---
+"wellcrafted": minor
+---
+
+Infer literal `queryKey` tuples in `defineQuery` without requiring `as const`. The `TQueryKey` type parameter now uses TypeScript 5.0's `const` modifier, so `queryKey: ['users', userId]` is inferred as `readonly ['users', string]` instead of being widened to `string[]`. This preserves the narrow key type on `.options.queryKey` and inside `queryFn`'s context, matching how TanStack Query types keys when you write them inline.
+
+Before:
+
+```ts
+const userQuery = defineQuery({
+  queryKey: ['users', userId] as const, // `as const` required to keep the tuple
+  queryFn: ({ queryKey }) => services.getUser(queryKey[1]),
+});
+```
+
+After:
+
+```ts
+const userQuery = defineQuery({
+  queryKey: ['users', userId], // inferred as readonly ['users', string]
+  queryFn: ({ queryKey }) => services.getUser(queryKey[1]),
+});
+```

--- a/src/query/utils.ts
+++ b/src/query/utils.ts
@@ -262,7 +262,7 @@ export function createQueryFactories(queryClient: QueryClient) {
 		TError = DefaultError,
 		TData = TQueryFnData,
 		TQueryData = TQueryFnData,
-		TQueryKey extends QueryKey = QueryKey,
+		const TQueryKey extends QueryKey = QueryKey,
 	>(
 		options: DefineQueryInput<
 			TQueryFnData,


### PR DESCRIPTION
Every `defineQuery` call site in downstream apps ends up tacking `as const` onto its `queryKey` just to keep TypeScript from widening the tuple to `string[]`. That `as const` is mechanical, repeated everywhere, and easy to forget. TanStack Query's own types model keys as readonly tuples; ours just weren't preserving them through inference.

```ts
// Before — `as const` required, or queryKey widens to string[]
defineQuery({
  queryKey: ['ffmpeg.checkInstalled'] as const,
  queryFn: ...,
});

// After — inferred as readonly ['ffmpeg.checkInstalled']
defineQuery({
  queryKey: ['ffmpeg.checkInstalled'],
  queryFn: ...,
});
```

The fix is one word: mark `TQueryKey` on `defineQuery` with TypeScript 5.0's `const` type parameter modifier.

```diff
 const defineQuery = <
   TQueryFnData = unknown,
   TError = DefaultError,
   TData = TQueryFnData,
   TQueryData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey,
+  const TQueryKey extends QueryKey = QueryKey,
 >(options: DefineQueryInput<...>): ... => { ... }
```

`const T` tells inference to treat the argument the way `as const` would: array literals become readonly tuples, string literals stay narrow. The narrow key then flows through to `.options.queryKey` and to `queryFn`'s `QueryFunctionContext<TQueryKey>`, matching how TanStack Query types keys you pass inline.

```
DefineQueryInput<TQueryFnData, TError, TData, TQueryData, TQueryKey>
                                                          │
                                                          ▼
   .options.queryKey: readonly ['ffmpeg.checkInstalled']
   queryFn ctx:        QueryFunctionContext<readonly ['ffmpeg.checkInstalled']>
```

`defineMutation` doesn't need the same treatment — its `mutationKey: MutationKey` field isn't generic, so nothing to widen. The two existing widening primitives in TanStack itself (`QueryKey` and `MutationKey` are both `ReadonlyArray<unknown>`) accept the narrower readonly tuple cleanly, so no contract changes downstream.

Bumping minor rather than patch: the inferred type at `.options.queryKey` genuinely changes from `string[]` to `readonly [...]`. The vast majority of consumers either don't touch `.options.queryKey` directly or treat it as readonly already, but anyone who assigned it to a mutable `string[]` will see a type error and should know to expect it.

Typecheck clean, 128/128 tests pass.