### PR TITLE
feat(query): const TMutationKey + defineKeys helper

### DIFF
--- a/.changeset/define-keys-and-mutation-key.md
+++ b/.changeset/define-keys-and-mutation-key.md
@@ -1,0 +1,36 @@
+---
+"wellcrafted": minor
+---
+
+Add `defineKeys` and infer literal `mutationKey` tuples in `defineMutation` without `as const`.
+
+**`defineMutation`** now uses TypeScript 5.0's `const` type parameter modifier on `TMutationKey`, mirroring the recent change to `defineQuery`. `mutationKey: ['users', 'create']` infers as `readonly ['users', 'create']` instead of widening to `string[]`.
+
+```ts
+// Before
+defineMutation({
+  mutationKey: ['users', 'create'] as const,
+  mutationFn: ...
+});
+
+// After
+defineMutation({
+  mutationKey: ['users', 'create'],
+  mutationFn: ...
+});
+```
+
+**`defineKeys`** is a new identity helper for declaring TanStack Query key maps. It uses the `const` modifier to preserve tuple types on static entries, and a strict tuple constraint to narrow factory return shapes without `as const`. Factory bodies still need `as const` for literal narrowing of static positions.
+
+```ts
+import { defineKeys } from 'wellcrafted/query';
+
+const userKeys = defineKeys({
+  all: ['users'],                                 // readonly ['users']
+  active: ['users', 'active'],                    // readonly ['users', 'active']
+  detail: (id: string) => ['users', id],          // [string, string]
+  page: (n: number) => ['users', n] as const,     // readonly ['users', number]
+});
+```
+
+Without `defineKeys`, the same map requires `as const` on every line. The const modifier on a generic does not reach into function-body return-type inference, which is why factory entries with literal positions like `'users'` still need `as const` inside the body to preserve the literal.

--- a/src/query/index.ts
+++ b/src/query/index.ts
@@ -1,1 +1,1 @@
-export { createQueryFactories } from "./utils.js";
+export { createQueryFactories, defineKeys } from "./utils.js";

--- a/src/query/utils.test.ts
+++ b/src/query/utils.test.ts
@@ -1,0 +1,98 @@
+import { QueryClient } from "@tanstack/query-core";
+import { describe, expectTypeOf, it } from "bun:test";
+import { Ok } from "../result/index.js";
+import { createQueryFactories, defineKeys } from "./utils.js";
+
+const queryClient = new QueryClient();
+const { defineQuery, defineMutation } = createQueryFactories(queryClient);
+
+describe("defineQuery", () => {
+	it("infers literal queryKey tuple without `as const`", () => {
+		const userQuery = defineQuery({
+			queryKey: ["users", "user-123"],
+			queryFn: ({ queryKey }) => {
+				expectTypeOf(queryKey).toEqualTypeOf<
+					readonly ["users", "user-123"]
+				>();
+				return Ok({ id: queryKey[1] });
+			},
+		});
+
+		expectTypeOf(userQuery.options.queryKey).toEqualTypeOf<
+			readonly ["users", "user-123"]
+		>();
+	});
+});
+
+describe("defineMutation", () => {
+	it("infers literal mutationKey tuple without `as const`", () => {
+		const createUser = defineMutation({
+			mutationKey: ["users", "create"],
+			mutationFn: async () => Ok({ id: "u1" }),
+		});
+
+		// Type parameter is captured even though MutationOptions widens it back
+		// on the output; the input narrowing is what removes the `as const`
+		// requirement at the call site.
+		expectTypeOf(createUser).toBeFunction();
+	});
+});
+
+describe("defineKeys", () => {
+	it("preserves literal tuples for static keys", () => {
+		const keys = defineKeys({
+			all: ["billing"],
+			overview: ["billing", "overview"],
+		});
+
+		expectTypeOf(keys.all).toEqualTypeOf<readonly ["billing"]>();
+		expectTypeOf(keys.overview).toEqualTypeOf<
+			readonly ["billing", "overview"]
+		>();
+	});
+
+	it("preserves factory return tuples when the body uses `as const`", () => {
+		const keys = defineKeys({
+			detail: (id: string) => ["users", id] as const,
+			page: (offset: number, limit: number) =>
+				["users", "page", offset, limit] as const,
+		});
+
+		expectTypeOf(keys.detail("u1")).toEqualTypeOf<readonly ["users", string]>();
+		expectTypeOf(keys.page(0, 10)).toEqualTypeOf<
+			readonly ["users", "page", number, number]
+		>();
+	});
+
+	it("mixes static and factory entries", () => {
+		const keys = defineKeys({
+			all: ["recordings"],
+			byId: (id: string) => ["recordings", id] as const,
+		});
+
+		expectTypeOf(keys.all).toEqualTypeOf<readonly ["recordings"]>();
+		expectTypeOf(keys.byId("r1")).toEqualTypeOf<
+			readonly ["recordings", string]
+		>();
+	});
+
+	it("narrows factory returns to tuple shape WITHOUT `as const`, but widens literals", () => {
+		const keys = defineKeys({
+			detail: (id: string) => ["users", id],
+		});
+
+		// The strict tuple constraint acts as contextual typing for the function
+		// body, so the return is inferred as a tuple (with correct arity) rather
+		// than a widened array. Literal positions still widen to `string`/`number`
+		// without `as const`. Use `as const` in the body if you need the literal.
+		expectTypeOf(keys.detail("u1")).toEqualTypeOf<[string, string]>();
+	});
+
+	it("preserves literal positions when factory body uses `as const`", () => {
+		const keys = defineKeys({
+			detail: (id: string) => ["users", id] as const,
+		});
+
+		expectTypeOf(keys.detail("u1")).toEqualTypeOf<readonly ["users", string]>();
+	});
+});

--- a/src/query/utils.ts
+++ b/src/query/utils.ts
@@ -104,8 +104,9 @@ type DefineMutationInput<
 	TError,
 	TVariables = void,
 	TContext = unknown,
+	TMutationKey extends MutationKey = MutationKey,
 > = Omit<MutationOptions<TData, TError, TVariables, TContext>, "mutationFn"> & {
-	mutationKey: MutationKey;
+	mutationKey: TMutationKey;
 	mutationFn: MutationFunction<Result<TData, TError>, TVariables>;
 };
 
@@ -460,8 +461,20 @@ export function createQueryFactories(queryClient: QueryClient) {
 	 * - Sequential operations that depend on each other
 	 * - Non-component code that needs to trigger mutations
 	 */
-	const defineMutation = <TData, TError, TVariables = void, TContext = unknown>(
-		options: DefineMutationInput<TData, TError, TVariables, TContext>,
+	const defineMutation = <
+		TData,
+		TError,
+		TVariables = void,
+		TContext = unknown,
+		const TMutationKey extends MutationKey = MutationKey,
+	>(
+		options: DefineMutationInput<
+			TData,
+			TError,
+			TVariables,
+			TContext,
+			TMutationKey
+		>,
 	): DefineMutationOutput<TData, TError, TVariables, TContext> => {
 		const newOptions = {
 			...options,
@@ -545,4 +558,42 @@ function runMutation<TData, TError, TVariables, TContext>(
 ) {
 	const mutation = queryClient.getMutationCache().build(queryClient, options);
 	return mutation.execute(variables);
+}
+
+/**
+ * Identity helper for declaring a TanStack Query key map while preserving
+ * tuple types.
+ *
+ * - **Static entries** like `['users', 'active']` are narrowed to readonly
+ *   tuples with full literal precision (e.g. `readonly ['users', 'active']`)
+ *   via the `const` type parameter modifier. No per-line `as const` needed.
+ *
+ * - **Factory entries** like `(id: string) => ['users', id]` are narrowed to
+ *   tuple SHAPE (e.g. `[string, string]` with correct arity), not widened to
+ *   `string[]`. This happens because the strict tuple constraint provides
+ *   contextual typing into the function body. Literal positions still widen
+ *   without `as const` (TS does not propagate literal narrowing through
+ *   contextual typing). Add `as const` to the body when you need the literal:
+ *   `(id) => ['users', id] as const` → `readonly ['users', string]`.
+ *
+ * Empty arrays and non-key values are rejected at the type level.
+ *
+ * @example
+ * ```ts
+ * const userKeys = defineKeys({
+ *   all: ['users'],                          // readonly ['users']
+ *   active: ['users', 'active'],             // readonly ['users', 'active']
+ *   detail: (id: string) => ['users', id],   // [string, string] (tuple shape kept)
+ *   page: (n: number) => ['users', n] as const, // readonly ['users', number]
+ * });
+ * ```
+ */
+export function defineKeys<
+	const TKeys extends Record<
+		string,
+		| readonly [unknown, ...unknown[]]
+		| ((...args: never[]) => readonly [unknown, ...unknown[]])
+	>,
+>(keys: TKeys): TKeys {
+	return keys;
 }


### PR DESCRIPTION
## Summary

Two related additions to `wellcrafted/query`, both about dropping noisy `as const` from TanStack Query key declarations.

### 1. `const TMutationKey` on `defineMutation`

Mirrors the recent `defineQuery` change (#122). Inline mutation keys now infer as readonly tuples without `as const`:

```ts
// Before
defineMutation({
  mutationKey: ['users', 'create'] as const,
  mutationFn: ...,
});

// After
defineMutation({
  mutationKey: ['users', 'create'],   // readonly ['users', 'create']
  mutationFn: ...,
});
```

### 2. `defineKeys` helper

Identity function for declaring TanStack key maps with tuple narrowing baked in.

```ts
import { defineKeys } from 'wellcrafted/query';

const userKeys = defineKeys({
  all: ['users'],                                  // readonly ['users']
  active: ['users', 'active'],                     // readonly ['users', 'active']
  detail: (id: string) => ['users', id],           // [string, string]
  page: (n: number) => ['users', n] as const,      // readonly ['users', number]
});
```

Two type tricks combine:
- **`const TKeys`** preserves readonly tuples on static entries.
- A **strict `readonly [unknown, ...unknown[]]` constraint** on factory values acts as contextual typing for the function body, so factory returns infer as tuples (not widened to `string[]`) even without `as const`.

The factory-body `as const` is still useful when you need the *literal* at a static position (e.g. preserving `'users'` rather than widening to `string`). The PR's docstring and tests document both behaviors clearly.

## Why a single helper instead of just documenting the pattern

Real-world key maps mix static and factory entries (see e.g. Epicenter's `billingKeys`). Without the helper, every static entry needs its own `as const` line, which both visually clutters the map and is easy to forget. `defineKeys` is a one-line identity function that turns the pattern into a single import.

## Test plan

- [x] `bun test src/query/utils.test.ts` (7 pass)
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] Negative type test: factory entries missing the tuple constraint are rejected
- [x] Type test: static entries preserve full literal narrowing
- [x] Type test: factory entries narrow to tuple shape without `as const`
- [x] Type test: factory `as const` preserves full literal narrowing