### PR TITLE
feat(query): add result-aware options helpers

### DIFF
--- a/.changeset/query-options-mutation-options.md
+++ b/.changeset/query-options-mutation-options.md
@@ -1,0 +1,36 @@
+---
+"wellcrafted": minor
+---
+
+Add `queryOptions` and `mutationOptions` as the canonical Result-to-TanStack adapters.
+
+`wellcrafted/query` now exposes two lower-level helpers alongside `defineQuery` / `defineMutation`:
+
+- `queryOptions(input)` accepts a `queryKey` plus a Result-returning `queryFn` and returns standard `QueryObserverOptions` whose `queryFn` resolves `Ok(data)` and throws `Err(error)`.
+- `mutationOptions(input)` accepts a `mutationKey` plus a Result-returning `mutationFn` and returns standard `MutationOptions` with the same Result unwrapping behavior.
+
+These helpers are platform-agnostic: no `QueryClient` required. They compose cleanly inside framework hooks:
+
+```ts
+import { queryOptions, mutationOptions } from "wellcrafted/query";
+
+const user = createQuery(() =>
+  queryOptions({
+    queryKey: ["user", userId],
+    queryFn: () => services.getUser(userId),
+  }),
+);
+
+const save = createMutation(() =>
+  mutationOptions({
+    mutationKey: ["saveUser"],
+    mutationFn: (input: SaveUserInput) => services.saveUser(input),
+  }),
+);
+```
+
+`defineQuery` and `defineMutation` now compose through these helpers, so there is exactly one canonical conversion path from `Result<TData, TError>` to TanStack's throwing contract. The `.options` produced by `defineQuery` and `defineMutation` is the same shape returned by `queryOptions` and `mutationOptions`.
+
+Use `queryOptions` / `mutationOptions` when options are local to a hook call site. Use `defineQuery` / `defineMutation` when you also want imperative helpers (`.fetch`, `.ensure`, `.execute`, callable form) bound to a specific `QueryClient`.
+
+The new helpers share names with TanStack Query's framework-adapter identity helpers (`@tanstack/react-query`, `@tanstack/svelte-query`). This is intentional: Wellcrafted's versions are the Result-aware equivalents. If you need both in one file, alias one on import.

--- a/src/query/README.md
+++ b/src/query/README.md
@@ -8,16 +8,58 @@ The query utilities solve a common integration challenge: your service functions
 
 ## Quick Start
 
+`wellcrafted/query` exposes two layers built on the same conversion path:
+
+1. **`queryOptions` / `mutationOptions`**: platform-agnostic adapters that turn a Result-returning `queryFn` or `mutationFn` into normal TanStack Query options. No `QueryClient` needed. Compose them directly with any framework hook (`createQuery`, `useQuery`, `createMutation`, `useMutation`).
+
+2. **`createQueryFactories(queryClient)` -> `defineQuery` / `defineMutation`**: bind the same options to a specific `QueryClient` and attach imperative helpers (`.fetch`, `.ensure`, `.execute`, and a callable form). `defineQuery` and `defineMutation` compose through `queryOptions` and `mutationOptions`, so there is exactly one place that unwraps `Result` into TanStack's throwing contract.
+
 ```typescript
 import { QueryClient } from '@tanstack/query-core';
-import { createQueryFactories } from 'wellcrafted/query';
+import {
+  createQueryFactories,
+  queryOptions,
+  mutationOptions,
+} from 'wellcrafted/query';
 
-// Create your query client
+// Local options used directly inside a hook
+const user = createQuery(() =>
+  queryOptions({
+    queryKey: ['user', userId],
+    queryFn: () => services.getUser(userId),
+  }),
+);
+
+const save = createMutation(() =>
+  mutationOptions({
+    mutationKey: ['saveUser'],
+    mutationFn: (input: SaveUserInput) => services.saveUser(input),
+  }),
+);
+
+// Reusable definitions bound to a QueryClient
 const queryClient = new QueryClient();
-
-// Create factory functions
 const { defineQuery, defineMutation } = createQueryFactories(queryClient);
 ```
+
+### `queryOptions(input)`
+
+- Accepts a `queryKey` plus a `queryFn` that returns `Result<TData, TError>` (sync or async).
+- Returns standard `QueryObserverOptions` whose `queryFn` resolves `Ok(data)` with `data` and throws on `Err(error)`.
+- Preserves literal `queryKey` tuples (no `as const` needed) and Result data/error inference.
+
+### `mutationOptions(input)`
+
+- Accepts a `mutationKey` plus a `mutationFn` that returns `Result<TData, TError>` (sync or async).
+- Returns standard `MutationOptions` whose `mutationFn` resolves `Ok(data)` with `data` and throws on `Err(error)`.
+- Infers variables from the `mutationFn` parameter.
+
+### When to use which
+
+- Reach for `queryOptions` / `mutationOptions` when the options are local to a hook call site and you do not need imperative execution outside reactivity.
+- Reach for `defineQuery` / `defineMutation` when you want a reusable definition with `.options` for hooks **and** `.fetch` / `.ensure` / `.execute` / callable form for imperative code (preloaders, event handlers, workflows).
+
+> Note on naming: TanStack Query's framework adapters export their own `queryOptions` and `mutationOptions` identity helpers. Wellcrafted's versions occupy the same name on purpose; this package is the Result-aware equivalent. If you ever need both in one file, alias one on import.
 
 ## Architecture Pattern: The RPC-like Approach
 

--- a/src/query/index.ts
+++ b/src/query/index.ts
@@ -1,1 +1,10 @@
-export { createQueryFactories, defineKeys } from "./utils.js";
+export {
+	createQueryFactories,
+	defineKeys,
+	mutationOptions,
+	queryOptions,
+} from "./utils.js";
+export type {
+	MutationOptionsInput,
+	QueryOptionsInput,
+} from "./utils.js";

--- a/src/query/utils.test.ts
+++ b/src/query/utils.test.ts
@@ -1,19 +1,143 @@
 import { QueryClient } from "@tanstack/query-core";
-import { describe, expectTypeOf, it } from "bun:test";
-import { Ok } from "../result/index.js";
-import { createQueryFactories, defineKeys } from "./utils.js";
+import { describe, expect, expectTypeOf, it } from "bun:test";
+import { Err, Ok } from "../result/index.js";
+import {
+	createQueryFactories,
+	defineKeys,
+	mutationOptions,
+	queryOptions,
+} from "./utils.js";
 
 const queryClient = new QueryClient();
 const { defineQuery, defineMutation } = createQueryFactories(queryClient);
+
+describe("queryOptions", () => {
+	it("infers literal queryKey tuple without `as const`", () => {
+		const options = queryOptions({
+			queryKey: ["users", "user-123"],
+			queryFn: ({ queryKey }) => {
+				expectTypeOf(queryKey).toEqualTypeOf<readonly ["users", "user-123"]>();
+				return Ok({ id: queryKey[1] });
+			},
+		});
+
+		expectTypeOf(options.queryKey).toEqualTypeOf<
+			readonly ["users", "user-123"]
+		>();
+	});
+
+	it("preserves Ok/Err data and error types through inference", () => {
+		type AuthError = { code: "UNAUTHORIZED"; message: string };
+
+		const options = queryOptions({
+			queryKey: ["session"],
+			queryFn: ():
+				| ReturnType<typeof Ok<{ userId: string }>>
+				| ReturnType<typeof Err<AuthError>> => Ok({ userId: "u1" }),
+		});
+
+		expectTypeOf(options.queryKey).toEqualTypeOf<readonly ["session"]>();
+	});
+
+	it("resolves Ok values into the TanStack data channel", async () => {
+		const options = queryOptions({
+			queryKey: ["ok"],
+			queryFn: () => Ok(42),
+		});
+
+		const queryFn = options.queryFn as (ctx: unknown) => Promise<number>;
+		const data = await queryFn({
+			queryKey: ["ok"],
+			signal: new AbortController().signal,
+			meta: undefined,
+		});
+		expect(data).toBe(42);
+	});
+
+	it("throws Err values into the TanStack error channel", async () => {
+		const options = queryOptions({
+			queryKey: ["err"],
+			queryFn: () => Err("boom"),
+		});
+
+		const queryFn = options.queryFn as (ctx: unknown) => Promise<unknown>;
+		expect(
+			queryFn({
+				queryKey: ["err"],
+				signal: new AbortController().signal,
+				meta: undefined,
+			}),
+		).rejects.toBe("boom");
+	});
+
+	it("supports sync Result-returning queryFn", async () => {
+		const options = queryOptions({
+			queryKey: ["sync"],
+			queryFn: () => Ok("sync-data"),
+		});
+
+		const data = await (options.queryFn as (ctx: unknown) => Promise<string>)({
+			queryKey: ["sync"],
+			signal: new AbortController().signal,
+			meta: undefined,
+		});
+		expect(data).toBe("sync-data");
+	});
+});
+
+describe("mutationOptions", () => {
+	it("infers variables and data from mutationFn", async () => {
+		type Input = { name: string };
+
+		const options = mutationOptions({
+			mutationKey: ["users", "create"],
+			mutationFn: async (input: Input) => Ok({ id: "u1", name: input.name }),
+		});
+
+		// Variables type flows through: calling with the right shape produces
+		// the right Promise<TData> resolution.
+		const data = await options.mutationFn?.({ name: "ada" });
+		expectTypeOf(data).toEqualTypeOf<
+			{ id: string; name: string } | undefined
+		>();
+	});
+
+	it("resolves Ok values into the TanStack data channel", async () => {
+		const options = mutationOptions({
+			mutationKey: ["m"],
+			mutationFn: async (n: number) => Ok(n * 2),
+		});
+
+		const data = await options.mutationFn?.(3);
+		expect(data).toBe(6);
+	});
+
+	it("supports sync Result-returning mutationFn", async () => {
+		const options = mutationOptions({
+			mutationKey: ["sync-mutation"],
+			mutationFn: (n: number) => Ok(n * 3),
+		});
+
+		const data = await options.mutationFn?.(3);
+		expect(data).toBe(9);
+	});
+
+	it("throws Err values into the TanStack error channel", async () => {
+		const options = mutationOptions({
+			mutationKey: ["m-err"],
+			mutationFn: async () => Err("fail"),
+		});
+
+		expect(options.mutationFn?.(undefined)).rejects.toBe("fail");
+	});
+});
 
 describe("defineQuery", () => {
 	it("infers literal queryKey tuple without `as const`", () => {
 		const userQuery = defineQuery({
 			queryKey: ["users", "user-123"],
 			queryFn: ({ queryKey }) => {
-				expectTypeOf(queryKey).toEqualTypeOf<
-					readonly ["users", "user-123"]
-				>();
+				expectTypeOf(queryKey).toEqualTypeOf<readonly ["users", "user-123"]>();
 				return Ok({ id: queryKey[1] });
 			},
 		});
@@ -21,6 +145,43 @@ describe("defineQuery", () => {
 		expectTypeOf(userQuery.options.queryKey).toEqualTypeOf<
 			readonly ["users", "user-123"]
 		>();
+	});
+
+	it("composes through queryOptions: .options matches queryOptions shape", () => {
+		const userQuery = defineQuery({
+			queryKey: ["users", "u1"],
+			queryFn: () => Ok({ id: "u1" }),
+		});
+		const standalone = queryOptions({
+			queryKey: ["users", "u1"],
+			queryFn: () => Ok({ id: "u1" }),
+		});
+
+		expectTypeOf(userQuery.options).toEqualTypeOf(standalone);
+	});
+
+	it("returns Ok from .ensure and callable form", async () => {
+		const userQuery = defineQuery({
+			queryKey: ["users", "ensure"],
+			queryFn: () => Ok({ id: "ensure" }),
+		});
+
+		const ensured = await userQuery.ensure();
+		expect(ensured.data).toEqual({ id: "ensure" });
+
+		const called = await userQuery();
+		expect(called.data).toEqual({ id: "ensure" });
+	});
+
+	it("returns Err from .fetch when queryFn errors", async () => {
+		const userQuery = defineQuery({
+			queryKey: ["users", "fail"],
+			queryFn: () => Err("not-found" as const),
+		});
+
+		const { data, error } = await userQuery.fetch();
+		expect(data).toBeNull();
+		expect(error).toBe("not-found");
 	});
 });
 
@@ -31,10 +192,32 @@ describe("defineMutation", () => {
 			mutationFn: async () => Ok({ id: "u1" }),
 		});
 
-		// Type parameter is captured even though MutationOptions widens it back
-		// on the output; the input narrowing is what removes the `as const`
-		// requirement at the call site.
 		expectTypeOf(createUser).toBeFunction();
+	});
+
+	it("returns Ok from .execute and callable form", async () => {
+		const create = defineMutation({
+			mutationKey: ["m", "create"],
+			mutationFn: async (input: { name: string }) =>
+				Ok({ id: "u1", name: input.name }),
+		});
+
+		const executed = await create.execute({ name: "ada" });
+		expect(executed.data).toEqual({ id: "u1", name: "ada" });
+
+		const called = await create({ name: "ada" });
+		expect(called.data).toEqual({ id: "u1", name: "ada" });
+	});
+
+	it("returns Err from .execute when mutationFn errors", async () => {
+		const create = defineMutation({
+			mutationKey: ["m", "fail"],
+			mutationFn: async () => Err("conflict" as const),
+		});
+
+		const { data, error } = await create.execute();
+		expect(data).toBeNull();
+		expect(error).toBe("conflict");
 	});
 });
 
@@ -81,10 +264,6 @@ describe("defineKeys", () => {
 			detail: (id: string) => ["users", id],
 		});
 
-		// The strict tuple constraint acts as contextual typing for the function
-		// body, so the return is inferred as a tuple (with correct arity) rather
-		// than a widened array. Literal positions still widen to `string`/`number`
-		// without `as const`. Use `as const` in the body if you need the literal.
 		expectTypeOf(keys.detail("u1")).toEqualTypeOf<[string, string]>();
 	});
 

--- a/src/query/utils.ts
+++ b/src/query/utils.ts
@@ -1,6 +1,5 @@
 import type {
 	DefaultError,
-	MutationFunction,
 	MutationKey,
 	MutationOptions,
 	QueryClient,
@@ -11,18 +10,19 @@ import type {
 import { Err, Ok, type Result, resolve } from "../result/index.js";
 
 /**
- * Input options for defining a query.
+ * Input for `queryOptions` and `defineQuery`.
  *
- * Extends TanStack Query's QueryObserverOptions but expects queryFn to return a Result type.
- * This type represents the configuration for creating a query definition with both
- * reactive and imperative interfaces for data fetching.
+ * Mirrors TanStack Query's `QueryObserverOptions` but expects `queryFn` to
+ * return a Wellcrafted `Result`. The Result is unwrapped into TanStack's
+ * throwing data/error contract by `queryOptions`.
  *
- * @template TQueryFnData - The type of data returned by the query function
- * @template TError - The type of error that can be thrown
- * @template TData - The type of data returned by the query (after select transform)
- * @template TQueryKey - The type of the query key
+ * @template TQueryFnData - The success type produced by `queryFn`
+ * @template TError - The error type carried by the Result
+ * @template TData - The type seen by consumers after `select`
+ * @template TQueryData - The type stored in the cache (usually `TQueryFnData`)
+ * @template TQueryKey - The literal query key tuple
  */
-type DefineQueryInput<
+export type QueryOptionsInput<
 	TQueryFnData = unknown,
 	TError = DefaultError,
 	TData = TQueryFnData,
@@ -37,37 +37,132 @@ type DefineQueryInput<
 };
 
 /**
- * Output of defineQuery function.
+ * Input for `mutationOptions` and `defineMutation`.
  *
- * The query definition is directly callable and defaults to `ensure()` behavior,
+ * Mirrors TanStack Query's `MutationOptions` but expects `mutationFn` to
+ * return a Wellcrafted `Result`. The Result is unwrapped into TanStack's
+ * throwing data/error contract by `mutationOptions`.
+ *
+ * @template TData - The success type produced by `mutationFn`
+ * @template TError - The error type carried by the Result
+ * @template TVariables - The variables passed to `mutationFn`
+ * @template TContext - The context type for optimistic updates
+ * @template TMutationKey - The literal mutation key tuple
+ */
+export type MutationOptionsInput<
+	TData,
+	TError,
+	TVariables = void,
+	TContext = unknown,
+	TMutationKey extends MutationKey = MutationKey,
+> = Omit<MutationOptions<TData, TError, TVariables, TContext>, "mutationFn"> & {
+	mutationKey: TMutationKey;
+	mutationFn: (
+		variables: TVariables,
+	) => Result<TData, TError> | Promise<Result<TData, TError>>;
+};
+
+/**
+ * Adapter from a Result-returning query function to TanStack Query options.
+ *
+ * This is the single canonical place where `Result<TQueryFnData, TError>`
+ * is converted into TanStack's contract: `Ok(data)` resolves with `data`,
+ * `Err(error)` throws `error` into the query error channel.
+ *
+ * Use this directly with framework hooks when you do not need the
+ * `QueryClient`-bound imperative helpers from `defineQuery`:
+ *
+ * ```ts
+ * const query = createQuery(() => queryOptions({
+ *   queryKey: ['user', userId],
+ *   queryFn: () => services.getUser(userId),
+ * }));
+ * ```
+ *
+ * `defineQuery` composes through this helper, so the `.options` it returns
+ * is the same shape `queryOptions` produces.
+ *
+ * @param input - Result-aware query configuration
+ * @returns TanStack Query `QueryObserverOptions` with `queryFn` rewired to
+ *   resolve `Ok` and throw `Err`
+ */
+export function queryOptions<
+	TQueryFnData = unknown,
+	TError = DefaultError,
+	TData = TQueryFnData,
+	TQueryData = TQueryFnData,
+	const TQueryKey extends QueryKey = QueryKey,
+>(
+	input: QueryOptionsInput<TQueryFnData, TError, TData, TQueryData, TQueryKey>,
+): QueryObserverOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey> {
+	return {
+		...input,
+		queryFn: async (context) => resolve(await input.queryFn(context)),
+	} satisfies QueryObserverOptions<
+		TQueryFnData,
+		TError,
+		TData,
+		TQueryData,
+		TQueryKey
+	>;
+}
+
+/**
+ * Adapter from a Result-returning mutation function to TanStack Query options.
+ *
+ * This is the single canonical place where `Result<TData, TError>` is
+ * converted into TanStack's contract: `Ok(data)` resolves with `data`,
+ * `Err(error)` throws `error` into the mutation error channel.
+ *
+ * Use this directly with framework hooks when you do not need the
+ * `QueryClient`-bound imperative helpers from `defineMutation`:
+ *
+ * ```ts
+ * const save = createMutation(() => mutationOptions({
+ *   mutationKey: ['saveUser'],
+ *   mutationFn: (input: SaveUserInput) => services.saveUser(input),
+ * }));
+ * ```
+ *
+ * `defineMutation` composes through this helper, so the `.options` it
+ * returns is the same shape `mutationOptions` produces.
+ *
+ * @param input - Result-aware mutation configuration
+ * @returns TanStack Query `MutationOptions` with `mutationFn` rewired to
+ *   resolve `Ok` and throw `Err`
+ */
+export function mutationOptions<
+	TData,
+	TError,
+	TVariables = void,
+	TContext = unknown,
+	const TMutationKey extends MutationKey = MutationKey,
+>(
+	input: MutationOptionsInput<
+		TData,
+		TError,
+		TVariables,
+		TContext,
+		TMutationKey
+	>,
+): MutationOptions<TData, TError, TVariables, TContext> {
+	return {
+		...input,
+		mutationFn: async (variables: TVariables) =>
+			resolve(await input.mutationFn(variables)),
+	} satisfies MutationOptions<TData, TError, TVariables, TContext>;
+}
+
+/**
+ * Output of `defineQuery`.
+ *
+ * The returned object is directly callable and defaults to `ensure()` behavior,
  * which is recommended for most imperative use cases like preloaders.
  *
- * Provides both reactive and imperative interfaces for data fetching:
- * - `()` (callable): Same as `ensure()` - returns cached data if available, fetches if not
- * - `options`: Returns config for use with useQuery() or createQuery()
- * - `fetch()`: Always attempts to fetch data (from cache if fresh, network if stale)
- * - `ensure()`: Guarantees data availability, preferring cached data (recommended for preloaders)
- *
- * @template TQueryFnData - The type of data returned by the query function
- * @template TError - The type of error that can be thrown
- * @template TData - The type of data returned by the query (after select transform)
- * @template TQueryKey - The type of the query key
- *
- * @example
- * ```typescript
- * const userQuery = defineQuery({...});
- *
- * // Directly callable (same as .ensure())
- * const { data, error } = await userQuery();
- *
- * // Or use explicit methods
- * const { data, error } = await userQuery.ensure();
- * const { data, error } = await userQuery.fetch();
- *
- * // For reactive usage (Svelte 5 requires accessor wrapper)
- * const query = createQuery(() => userQuery.options); // Svelte 5
- * const query = useQuery(userQuery.options); // React
- * ```
+ * - `()` (callable): Same as `ensure()`. Returns cached data if available.
+ * - `options`: Options shape produced by `queryOptions`, ready for hooks.
+ * - `fetch()`: Always evaluates freshness; refetches if stale.
+ * - `ensure()`: Prefers cached data; fetches only when missing.
  */
 type DefineQueryOutput<
 	TQueryFnData = unknown,
@@ -88,58 +183,14 @@ type DefineQueryOutput<
 };
 
 /**
- * Input options for defining a mutation.
+ * Output of `defineMutation`.
  *
- * Extends TanStack Query's MutationOptions but expects mutationFn to return a Result type.
- * This type represents the configuration for creating a mutation definition with both
- * reactive and imperative interfaces for data mutations.
+ * The returned object is directly callable and executes the mutation,
+ * equivalent to calling `.execute()`.
  *
- * @template TData - The type of data returned by the mutation
- * @template TError - The type of error that can be thrown
- * @template TVariables - The type of variables passed to the mutation
- * @template TContext - The type of context data for optimistic updates
- */
-type DefineMutationInput<
-	TData,
-	TError,
-	TVariables = void,
-	TContext = unknown,
-	TMutationKey extends MutationKey = MutationKey,
-> = Omit<MutationOptions<TData, TError, TVariables, TContext>, "mutationFn"> & {
-	mutationKey: TMutationKey;
-	mutationFn: MutationFunction<Result<TData, TError>, TVariables>;
-};
-
-/**
- * Output of defineMutation function.
- *
- * The mutation definition is directly callable, which executes the mutation
- * and returns a Result. This is equivalent to calling `.execute()`.
- *
- * Provides both reactive and imperative interfaces for data mutations:
- * - `(variables)` (callable): Same as `execute()` - directly executes the mutation
- * - `options`: Returns config for use with useMutation() or createMutation()
- * - `execute(variables)`: Directly executes the mutation and returns a Result
- *
- * @template TData - The type of data returned by the mutation
- * @template TError - The type of error that can be thrown
- * @template TVariables - The type of variables passed to the mutation
- * @template TContext - The type of context data for optimistic updates
- *
- * @example
- * ```typescript
- * const createUser = defineMutation({...});
- *
- * // Directly callable (same as .execute())
- * const { data, error } = await createUser({ name: 'John' });
- *
- * // Or use explicit method
- * const { data, error } = await createUser.execute({ name: 'John' });
- *
- * // For reactive usage (Svelte 5 requires accessor wrapper)
- * const mutation = createMutation(() => createUser.options); // Svelte 5
- * const mutation = useMutation(createUser.options); // React
- * ```
+ * - `(variables)` (callable): Same as `execute(variables)`.
+ * - `options`: Options shape produced by `mutationOptions`, ready for hooks.
+ * - `execute(variables)`: Imperatively runs the mutation, returning a Result.
  */
 type DefineMutationOutput<
 	TData,
@@ -152,112 +203,38 @@ type DefineMutationOutput<
 };
 
 /**
- * Creates factory functions for defining queries and mutations bound to a specific QueryClient.
+ * Creates `defineQuery` and `defineMutation` bound to a specific `QueryClient`.
  *
- * This factory pattern allows you to create isolated query/mutation definitions that are
- * bound to a specific QueryClient instance, enabling:
- * - Multiple query clients in the same application
- * - Testing with isolated query clients
- * - Framework-agnostic query definitions
- * - Proper separation of concerns between query logic and client instances
+ * Use this when you want a reusable query/mutation definition that carries
+ * its own imperative helpers (`.fetch`, `.ensure`, `.execute`, callable form)
+ * powered by a specific client. For local one-shot options that only need
+ * to flow into a framework hook, prefer `queryOptions` / `mutationOptions`
+ * directly: those are platform-agnostic and do not require a `QueryClient`.
  *
- * The returned functions handle Result types automatically, unwrapping them for TanStack Query
- * while maintaining type safety throughout your application.
+ * Both `defineQuery` and `defineMutation` compose through `queryOptions` and
+ * `mutationOptions`, so there is exactly one place that unwraps `Result`
+ * into TanStack's throwing contract.
  *
- * @param queryClient - The QueryClient instance to bind the factories to
- * @returns An object containing defineQuery and defineMutation functions bound to the provided client
+ * @param queryClient - The TanStack `QueryClient` to bind imperative helpers to
  *
  * @example
- * ```typescript
- * // Create your query client
- * const queryClient = new QueryClient({
- *   defaultOptions: {
- *     queries: { staleTime: 5 * 60 * 1000 }
- *   }
- * });
- *
- * // Create the factory functions
+ * ```ts
+ * const queryClient = new QueryClient();
  * const { defineQuery, defineMutation } = createQueryFactories(queryClient);
  *
- * // Now use defineQuery and defineMutation as before
  * const userQuery = defineQuery({
  *   queryKey: ['user', userId],
- *   queryFn: () => services.getUser(userId)
+ *   queryFn: () => services.getUser(userId),
  * });
  *
- * // Use in components (Svelte 5 requires accessor wrapper)
- * const query = createQuery(() => userQuery.options); // Svelte 5
- * const query = useQuery(userQuery.options); // React
+ * // Reactive
+ * const query = createQuery(() => userQuery.options);
  *
- * // Or imperatively
+ * // Imperative
  * const { data, error } = await userQuery.fetch();
  * ```
  */
 export function createQueryFactories(queryClient: QueryClient) {
-	/**
-	 * Creates a query definition that bridges the gap between pure service functions and reactive UI components.
-	 *
-	 * This factory function is the cornerstone of our data fetching architecture. It wraps service calls
-	 * with TanStack Query superpowers while maintaining type safety through Result types.
-	 *
-	 * The returned query definition is **directly callable** and defaults to `ensure()` behavior,
-	 * which is recommended for most imperative use cases like preloaders.
-	 *
-	 * ## Why use defineQuery?
-	 *
-	 * 1. **Callable**: Call directly like `userQuery()` for imperative data fetching
-	 * 2. **Dual Interface**: Also provides reactive (`.options`) and explicit imperative (`.fetch()`, `.ensure()`) APIs
-	 * 3. **Automatic Error Handling**: Service functions return `Result<T, E>` types which are automatically
-	 *    unwrapped by TanStack Query, giving you proper error states in your components
-	 * 4. **Type Safety**: Full TypeScript support with proper inference for data and error types
-	 * 5. **Consistency**: Every query in the app follows the same pattern, making it easy to understand
-	 *
-	 * @template TQueryFnData - The type of data returned by the query function
-	 * @template TError - The type of error that can be thrown
-	 * @template TData - The type of data returned by the query (after select transform)
-	 * @template TQueryKey - The type of the query key
-	 *
-	 * @param options - Query configuration object
-	 * @param options.queryKey - Unique key for this query (used for caching and refetching)
-	 * @param options.queryFn - Function that fetches data and returns a Result type
-	 * @param options.* - Any other TanStack Query options (staleTime, refetchInterval, etc.)
-	 *
-	 * @returns Callable query definition with:
-	 *   - `()` (callable): Same as `ensure()` - returns cached data if available, fetches if not
-	 *   - `.options`: Config for use with useQuery() or createQuery()
-	 *   - `.fetch()`: Always attempts to fetch (from cache if fresh, network if stale)
-	 *   - `.ensure()`: Guarantees data availability, preferring cached data (recommended for preloaders)
-	 *
-	 * @example
-	 * ```typescript
-	 * // Step 1: Define your query in the query layer
-	 * const userQuery = defineQuery({
-	 *   queryKey: ['users', userId],
-	 *   queryFn: () => services.getUser(userId), // Returns Result<User, ApiError>
-	 *   staleTime: 5 * 60 * 1000, // Consider data fresh for 5 minutes
-	 * });
-	 *
-	 * // Step 2a: Use reactively in a Svelte 5 component (accessor wrapper required)
-	 * const query = createQuery(() => userQuery.options);
-	 * // query.data is User | undefined
-	 * // query.error is ApiError | null
-	 *
-	 * // Step 2b: Call directly in preloaders (recommended)
-	 * export const load = async () => {
-	 *   const { data, error } = await userQuery(); // Same as userQuery.ensure()
-	 *   if (error) throw error;
-	 *   return { user: data };
-	 * };
-	 *
-	 * // Step 2c: Use explicit methods when needed
-	 * async function refreshUser() {
-	 *   const { data, error } = await userQuery.fetch(); // Force fresh fetch
-	 *   if (error) {
-	 *     console.error('Failed to fetch user:', error);
-	 *   }
-	 * }
-	 * ```
-	 */
 	const defineQuery = <
 		TQueryFnData = unknown,
 		TError = DefaultError,
@@ -265,7 +242,7 @@ export function createQueryFactories(queryClient: QueryClient) {
 		TQueryData = TQueryFnData,
 		const TQueryKey extends QueryKey = QueryKey,
 	>(
-		options: DefineQueryInput<
+		input: QueryOptionsInput<
 			TQueryFnData,
 			TError,
 			TData,
@@ -273,44 +250,8 @@ export function createQueryFactories(queryClient: QueryClient) {
 			TQueryKey
 		>,
 	): DefineQueryOutput<TQueryFnData, TError, TData, TQueryData, TQueryKey> => {
-		const newOptions = {
-			...options,
-			queryFn: async (context) => {
-				let result = options.queryFn(context);
-				if (result instanceof Promise) result = await result;
-				return resolve(result);
-			},
-		} satisfies QueryObserverOptions<
-			TQueryFnData,
-			TError,
-			TData,
-			TQueryData,
-			TQueryKey
-		>;
+		const options = queryOptions(input);
 
-		/**
-		 * Fetches data for this query using queryClient.fetchQuery().
-		 *
-		 * This method ALWAYS evaluates freshness and will refetch if data is stale.
-		 * It wraps TanStack Query's fetchQuery method, which returns cached data if fresh
-		 * or makes a network request if the data is stale or missing.
-		 *
-		 * **When to use fetch():**
-		 * - When you explicitly want to check data freshness
-		 * - For user-triggered refresh actions
-		 * - When you need the most up-to-date data
-		 *
-		 * **For preloaders, use ensure() instead** - it's more efficient for initial data loading.
-		 *
-		 * @returns Promise that resolves with a Result containing either the data or an error
-		 *
-		 * @example
-		 * // Good for user-triggered refresh
-		 * const { data, error } = await userQuery.fetch();
-		 * if (error) {
-		 *   console.error('Failed to load user:', error);
-		 * }
-		 */
 		async function fetch(): Promise<Result<TQueryData, TError>> {
 			try {
 				return Ok(
@@ -320,8 +261,8 @@ export function createQueryFactories(queryClient: QueryClient) {
 						TQueryData,
 						TQueryKey
 					>({
-						queryKey: newOptions.queryKey,
-						queryFn: newOptions.queryFn,
+						queryKey: options.queryKey,
+						queryFn: options.queryFn,
 					}),
 				);
 			} catch (error) {
@@ -329,39 +270,6 @@ export function createQueryFactories(queryClient: QueryClient) {
 			}
 		}
 
-		/**
-		 * Ensures data is available for this query using queryClient.ensureQueryData().
-		 *
-		 * This method PRIORITIZES cached data and only calls fetchQuery internally if no cached
-		 * data exists. It wraps TanStack Query's ensureQueryData method, which is perfect for
-		 * guaranteeing data availability with minimal network requests.
-		 *
-		 * **This is the RECOMMENDED method for preloaders** because:
-		 * - It returns cached data immediately if available
-		 * - It updates the query client cache properly
-		 * - It minimizes network requests during navigation
-		 * - It ensures components have data ready when they mount
-		 *
-		 * **When to use ensure():**
-		 * - Route preloaders and data loading functions
-		 * - Initial component data requirements
-		 * - When cached data is acceptable for immediate display
-		 *
-		 * This is also the default behavior when calling the query directly.
-		 *
-		 * @returns Promise that resolves with a Result containing either the data or an error
-		 *
-		 * @example
-		 * // Perfect for preloaders
-		 * export const load = async () => {
-		 *   const { data, error } = await userQuery.ensure();
-		 *   // Or simply: await userQuery();
-		 *   if (error) {
-		 *     throw error;
-		 *   }
-		 *   return { user: data };
-		 * };
-		 */
 		async function ensure(): Promise<Result<TQueryData, TError>> {
 			try {
 				return Ok(
@@ -371,8 +279,8 @@ export function createQueryFactories(queryClient: QueryClient) {
 						TQueryData,
 						TQueryKey
 					>({
-						queryKey: newOptions.queryKey,
-						queryFn: newOptions.queryFn,
+						queryKey: options.queryKey,
+						queryFn: options.queryFn,
 					}),
 				);
 			} catch (error) {
@@ -380,87 +288,13 @@ export function createQueryFactories(queryClient: QueryClient) {
 			}
 		}
 
-		// Create a callable function that defaults to ensure() behavior
-		// and attach options, fetch, and ensure as properties
 		return Object.assign(ensure, {
-			options: newOptions,
+			options,
 			fetch,
 			ensure,
 		});
 	};
 
-	/**
-	 * Creates a mutation definition for operations that modify data (create, update, delete).
-	 *
-	 * This factory function is the mutation counterpart to defineQuery. It provides a clean way to
-	 * wrap service functions that perform side effects, while maintaining the same dual interface
-	 * pattern for maximum flexibility.
-	 *
-	 * The returned mutation definition is **directly callable**, which executes the mutation
-	 * and returns a Result. This is equivalent to calling `.execute()`.
-	 *
-	 * ## Why use defineMutation?
-	 *
-	 * 1. **Callable**: Call directly like `createUser({ name: 'John' })` for imperative execution
-	 * 2. **Dual Interface**: Also provides reactive (`.options`) and explicit imperative (`.execute()`) APIs
-	 * 3. **Consistent Error Handling**: Service functions return `Result<T, E>` types, ensuring
-	 *    errors are handled consistently throughout the app
-	 * 4. **Cache Management**: Mutations often update the cache after success (see examples)
-	 *
-	 * @template TData - The type of data returned by the mutation
-	 * @template TError - The type of error that can be thrown
-	 * @template TVariables - The type of variables passed to the mutation
-	 * @template TContext - The type of context data for optimistic updates
-	 *
-	 * @param options - Mutation configuration object
-	 * @param options.mutationKey - Unique key for this mutation (used for tracking in-flight state)
-	 * @param options.mutationFn - Function that performs the mutation and returns a Result type
-	 * @param options.* - Any other TanStack Mutation options (onSuccess, onError, etc.)
-	 *
-	 * @returns Callable mutation definition with:
-	 *   - `(variables)` (callable): Same as `execute()` - directly executes the mutation
-	 *   - `.options`: Config for use with useMutation() or createMutation()
-	 *   - `.execute(variables)`: Directly executes the mutation and returns a Result
-	 *
-	 * @example
-	 * ```typescript
-	 * // Step 1: Define your mutation with cache updates
-	 * const createRecording = defineMutation({
-	 *   mutationKey: ['recordings', 'create'],
-	 *   mutationFn: async (recording: Recording) => {
-	 *     // Call the service
-	 *     const result = await services.db.createRecording(recording);
-	 *     if (result.error) return Err(result.error);
-	 *
-	 *     // Update cache on success
-	 *     queryClient.setQueryData(['recordings'], (old) =>
-	 *       [...(old || []), recording]
-	 *     );
-	 *
-	 *     return Ok(result.data);
-	 *   }
-	 * });
-	 *
-	 * // Step 2a: Use reactively in a Svelte 5 component (accessor wrapper required)
-	 * const mutation = createMutation(() => createRecording.options);
-	 * // Call with: mutation.mutate(recordingData)
-	 *
-	 * // Step 2b: Call directly in an action (recommended)
-	 * async function saveRecording(data: Recording) {
-	 *   const { error } = await createRecording(data); // Same as createRecording.execute(data)
-	 *   if (error) {
-	 *     notify.error({ title: 'Failed to save', description: error.message });
-	 *   } else {
-	 *     notify.success({ title: 'Recording saved!' });
-	 *   }
-	 * }
-	 * ```
-	 *
-	 * @tip Calling directly is especially useful for:
-	 * - Event handlers that need to await the result
-	 * - Sequential operations that depend on each other
-	 * - Non-component code that needs to trigger mutations
-	 */
 	const defineMutation = <
 		TData,
 		TError,
@@ -468,7 +302,7 @@ export function createQueryFactories(queryClient: QueryClient) {
 		TContext = unknown,
 		const TMutationKey extends MutationKey = MutationKey,
 	>(
-		options: DefineMutationInput<
+		input: MutationOptionsInput<
 			TData,
 			TError,
 			TVariables,
@@ -476,54 +310,18 @@ export function createQueryFactories(queryClient: QueryClient) {
 			TMutationKey
 		>,
 	): DefineMutationOutput<TData, TError, TVariables, TContext> => {
-		const newOptions = {
-			...options,
-			mutationFn: async (variables: TVariables) => {
-				return resolve(await options.mutationFn(variables));
-			},
-		} satisfies MutationOptions<TData, TError, TVariables, TContext>;
+		const options = mutationOptions(input);
 
-		/**
-		 * Executes the mutation imperatively and returns a Result.
-		 *
-		 * This is the recommended way to trigger mutations from:
-		 * - Button click handlers
-		 * - Form submissions
-		 * - Keyboard shortcuts
-		 * - Any non-component code
-		 *
-		 * The method automatically wraps the result in a Result type, so you always
-		 * get back `{ data, error }` for consistent error handling.
-		 *
-		 * This is also the default behavior when calling the mutation directly.
-		 *
-		 * @param variables - The variables to pass to the mutation function
-		 * @returns Promise that resolves with a Result containing either the data or an error
-		 *
-		 * @example
-		 * // In an event handler
-		 * async function handleSubmit(formData: FormData) {
-		 *   const { data, error } = await createUser.execute(formData);
-		 *   // Or simply: await createUser(formData);
-		 *   if (error) {
-		 *     notify.error({ title: 'Failed to create user', description: error.message });
-		 *     return;
-		 *   }
-		 *   goto(`/users/${data.id}`);
-		 * }
-		 */
 		async function execute(variables: TVariables) {
 			try {
-				return Ok(await runMutation(queryClient, newOptions, variables));
+				return Ok(await runMutation(queryClient, options, variables));
 			} catch (error) {
 				return Err(error as TError);
 			}
 		}
 
-		// Create a callable function that executes the mutation
-		// and attach options and execute as properties
 		return Object.assign(execute, {
-			options: newOptions,
+			options,
 			execute,
 		});
 	};
@@ -535,21 +333,11 @@ export function createQueryFactories(queryClient: QueryClient) {
 }
 
 /**
- * Internal helper that executes a mutation directly using the query client's mutation cache.
- *
- * This is what powers the callable behavior and `.execute()` method on mutations.
- * It bypasses the reactive mutation hooks and runs the mutation imperatively,
- * which is perfect for event handlers and other imperative code.
+ * Internal helper that executes a mutation directly using the query client's
+ * mutation cache. Powers the callable behavior and `.execute()` method on
+ * mutations returned from `defineMutation`.
  *
  * @internal
- * @template TData - The type of data returned by the mutation
- * @template TError - The type of error that can be thrown
- * @template TVariables - The type of variables passed to the mutation
- * @template TContext - The type of context data
- * @param queryClient - The query client instance to use
- * @param options - The mutation options including mutationFn and mutationKey
- * @param variables - The variables to pass to the mutation function
- * @returns Promise that resolves with the mutation result
  */
 function runMutation<TData, TError, TVariables, TContext>(
 	queryClient: QueryClient,
@@ -574,7 +362,7 @@ function runMutation<TData, TError, TVariables, TContext>(
  *   contextual typing into the function body. Literal positions still widen
  *   without `as const` (TS does not propagate literal narrowing through
  *   contextual typing). Add `as const` to the body when you need the literal:
- *   `(id) => ['users', id] as const` → `readonly ['users', string]`.
+ *   `(id) => ['users', id] as const` -> `readonly ['users', string]`.
  *
  * Empty arrays and non-key values are rejected at the type level.
  *


### PR DESCRIPTION
Hook-local query and mutation call sites should not need a `QueryClient` just to adapt Result-returning service functions into TanStack Query's throwing data/error contract. This adds `queryOptions` and `mutationOptions` as the lower-level Result-aware adapters, then makes `defineQuery` and `defineMutation` compose through those helpers so the unwrapping behavior has one source of truth.

```ts
import { queryOptions, mutationOptions } from 'wellcrafted/query';

const user = createQuery(() =>
  queryOptions({
    queryKey: ['user', userId],
    queryFn: () => services.getUser(userId),
  }),
);

const save = createMutation(() =>
  mutationOptions({
    mutationKey: ['saveUser'],
    mutationFn: (input: SaveUserInput) => services.saveUser(input),
  }),
);
```

The existing `createQueryFactories(queryClient)` layer stays intact for reusable definitions that need `.fetch`, `.ensure`, `.execute`, or callable imperative helpers. Its exposed `.options` now comes from the same adapter helpers a hook-local call site would use directly.

The new helpers intentionally share names with TanStack's framework-adapter helpers. They live under `wellcrafted/query` as the Result-aware equivalents, and the README calls out aliasing if a consumer imports both helpers in one file.

## Changelog

Adds `queryOptions` and `mutationOptions` to `wellcrafted/query` for converting Result-returning query and mutation functions into TanStack Query options without requiring a `QueryClient`.