### PR TITLE
fix(query): tighten Result-aware hook options

### DIFF
--- a/docs/integrations/tanstack-query.mdx
+++ b/docs/integrations/tanstack-query.mdx
@@ -544,6 +544,7 @@ Mutations are directly callable. Queries are intentionally explicit because `.fe
 ```typescript
 // ✅ Good: Transform at query layer
 const getUser = defineQuery({
+  queryKey: ['users', id],
   queryFn: async () => {
     const { data, error } = await services.db.getUser(id);
     if (error) {

--- a/docs/patterns/error-transformation.mdx
+++ b/docs/patterns/error-transformation.mdx
@@ -292,7 +292,10 @@ function handleUIError(error: UIError) {
 
 ```typescript
 // Bad
-const getUser = defineQuery({ queryFn: () => services.getUser(id) });
+const getUser = defineQuery({
+  queryKey: ['users', id],
+  queryFn: () => services.getUser(id),
+});
 ```
 
 **Don't transform errors in components** -- do it once in the query layer:

--- a/src/query/README.md
+++ b/src/query/README.md
@@ -51,7 +51,7 @@ const { defineQuery, defineMutation } = createQueryFactories(queryClient);
 ### `mutationOptions(input)`
 
 - Accepts a `mutationKey` plus a `mutationFn` that returns `Result<TData, TError>` (sync or async).
-- Returns standard `MutationOptions` whose `mutationFn` resolves `Ok(data)` with `data` and throws on `Err(error)`.
+- Returns standard mutation observer options whose `mutationFn` resolves `Ok(data)` with `data` and throws on `Err(error)`.
 - Infers variables from the `mutationFn` parameter.
 
 ### When to use which
@@ -174,7 +174,7 @@ export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 5 * 60 * 1000, // 5 minutes
-      cacheTime: 10 * 60 * 1000, // 10 minutes
+      gcTime: 10 * 60 * 1000, // 10 minutes
     },
   },
 });

--- a/src/query/index.ts
+++ b/src/query/index.ts
@@ -4,7 +4,3 @@ export {
 	mutationOptions,
 	queryOptions,
 } from "./utils.js";
-export type {
-	MutationOptionsInput,
-	QueryOptionsInput,
-} from "./utils.js";

--- a/src/query/utils.test.ts
+++ b/src/query/utils.test.ts
@@ -1,4 +1,8 @@
 import { QueryClient } from "@tanstack/query-core";
+import type {
+	MutationObserverOptions,
+	QueryObserverOptions,
+} from "@tanstack/query-core";
 import { describe, expect, expectTypeOf, it } from "bun:test";
 import { Err, Ok } from "../result/index.js";
 import {
@@ -37,6 +41,15 @@ describe("queryOptions", () => {
 		});
 
 		expectTypeOf(options.queryKey).toEqualTypeOf<readonly ["session"]>();
+		expectTypeOf(options).toEqualTypeOf<
+			QueryObserverOptions<
+				{ userId: string },
+				AuthError,
+				{ userId: string },
+				{ userId: string },
+				readonly ["session"]
+			>
+		>();
 	});
 
 	it("resolves Ok values into the TanStack data channel", async () => {
@@ -88,10 +101,16 @@ describe("queryOptions", () => {
 describe("mutationOptions", () => {
 	it("infers variables and data from mutationFn", async () => {
 		type Input = { name: string };
+		type SaveError = { code: "CONFLICT"; message: string };
 
 		const options = mutationOptions({
 			mutationKey: ["users", "create"],
-			mutationFn: async (input: Input) => Ok({ id: "u1", name: input.name }),
+			mutationFn: (
+				input: Input,
+			):
+				| ReturnType<typeof Ok<{ id: string; name: string }>>
+				| ReturnType<typeof Err<SaveError>> =>
+				Ok({ id: "u1", name: input.name }),
 		});
 
 		// Variables type flows through: calling with the right shape produces
@@ -99,6 +118,31 @@ describe("mutationOptions", () => {
 		const data = await options.mutationFn?.({ name: "ada" });
 		expectTypeOf(data).toEqualTypeOf<
 			{ id: string; name: string } | undefined
+		>();
+		expectTypeOf(options).toEqualTypeOf<
+			MutationObserverOptions<
+				{ id: string; name: string },
+				SaveError,
+				Input,
+				unknown
+			>
+		>();
+	});
+
+	it("accepts observer-only hook options", () => {
+		type SaveError = { code: "CONFLICT"; message: string };
+
+		const options = mutationOptions({
+			mutationKey: ["users", "create"],
+			mutationFn: (input: { name: string }) =>
+				input.name.length > 0
+					? Ok({ id: "u1", name: input.name })
+					: Err<SaveError>({ code: "CONFLICT", message: "Name is required." }),
+			throwOnError: (error) => error.code === "CONFLICT",
+		});
+
+		expectTypeOf(options.throwOnError).toEqualTypeOf<
+			boolean | ((error: SaveError) => boolean) | undefined
 		>();
 	});
 
@@ -221,7 +265,7 @@ describe("defineQuery", () => {
 });
 
 describe("defineMutation", () => {
-	it("infers literal mutationKey tuple without `as const`", () => {
+	it("accepts literal mutationKey tuple without `as const`", () => {
 		const createUser = defineMutation({
 			mutationKey: ["users", "create"],
 			mutationFn: async () => Ok({ id: "u1" }),

--- a/src/query/utils.ts
+++ b/src/query/utils.ts
@@ -1,6 +1,7 @@
 import type {
 	DefaultError,
 	MutationKey,
+	MutationObserverOptions,
 	MutationOptions,
 	QueryClient,
 	QueryFunction,
@@ -22,7 +23,7 @@ import { Err, Ok, type Result, resolve } from "../result/index.js";
  * @template TQueryData - The type stored in the cache (usually `TQueryFnData`)
  * @template TQueryKey - The literal query key tuple
  */
-export type QueryOptionsInput<
+type QueryOptionsInput<
 	TQueryFnData = unknown,
 	TError = DefaultError,
 	TData = TQueryFnData,
@@ -39,8 +40,8 @@ export type QueryOptionsInput<
 /**
  * Input for `mutationOptions` and `defineMutation`.
  *
- * Mirrors TanStack Query's `MutationOptions` but expects `mutationFn` to
- * return a Wellcrafted `Result`. The Result is unwrapped into TanStack's
+ * Mirrors TanStack Query's `MutationObserverOptions` but expects `mutationFn`
+ * to return a Wellcrafted `Result`. The Result is unwrapped into TanStack's
  * throwing data/error contract by `mutationOptions`.
  *
  * @template TData - The success type produced by `mutationFn`
@@ -49,13 +50,16 @@ export type QueryOptionsInput<
  * @template TContext - The context type for optimistic updates
  * @template TMutationKey - The literal mutation key tuple
  */
-export type MutationOptionsInput<
+type MutationOptionsInput<
 	TData,
 	TError,
 	TVariables = void,
 	TContext = unknown,
 	TMutationKey extends MutationKey = MutationKey,
-> = Omit<MutationOptions<TData, TError, TVariables, TContext>, "mutationFn"> & {
+> = Omit<
+	MutationObserverOptions<TData, TError, TVariables, TContext>,
+	"mutationFn"
+> & {
 	mutationKey: TMutationKey;
 	mutationFn: (
 		variables: TVariables,
@@ -128,8 +132,8 @@ export function queryOptions<
  * returns is the same shape `mutationOptions` produces.
  *
  * @param input - Result-aware mutation configuration
- * @returns TanStack Query `MutationOptions` with `mutationFn` rewired to
- *   resolve `Ok` and throw `Err`
+ * @returns TanStack Query `MutationObserverOptions` with `mutationFn` rewired
+ *   to resolve `Ok` and throw `Err`
  */
 export function mutationOptions<
 	TData,
@@ -145,12 +149,12 @@ export function mutationOptions<
 		TContext,
 		TMutationKey
 	>,
-): MutationOptions<TData, TError, TVariables, TContext> {
+): MutationObserverOptions<TData, TError, TVariables, TContext> {
 	return {
 		...input,
 		mutationFn: async (variables: TVariables) =>
 			resolve(await input.mutationFn(variables)),
-	} satisfies MutationOptions<TData, TError, TVariables, TContext>;
+	} satisfies MutationObserverOptions<TData, TError, TVariables, TContext>;
 }
 
 /**
@@ -194,7 +198,7 @@ type DefineMutationOutput<
 	TVariables = void,
 	TContext = unknown,
 > = ((variables: TVariables) => Promise<Result<TData, TError>>) & {
-	options: MutationOptions<TData, TError, TVariables, TContext>;
+	options: MutationObserverOptions<TData, TError, TVariables, TContext>;
 };
 
 /**


### PR DESCRIPTION
This follow-up keeps the query API surface aligned with the PR #128 and #130 intent. Mutation definitions advertise .options as the shared hook bridge, so the options type now matches TanStack's mutation observer options instead of the narrower core mutation options. That keeps hook-only fields such as throwOnError available while preserving the imperative mutation runner.

The pass also collapses the exported input aliases out of the public barrel. They were not part of the intended surface and made the mutation naming easier to confuse with TanStack's own core type. The aliases still exist internally for the generated function signatures.

The docs cleanup fixes stale examples that would otherwise teach v4 cacheTime or invalid defineQuery calls without queryKey.