### PR TITLE
fix(function): rethrow cached once failure

### DIFF
--- a/.changeset/tidy-spoons-repeat.md
+++ b/.changeset/tidy-spoons-repeat.md
@@ -1,0 +1,5 @@
+---
+"wellcrafted": patch
+---
+
+Make `once` rethrow the first call's failure on later calls instead of returning `undefined`.

--- a/src/function.test.ts
+++ b/src/function.test.ts
@@ -49,6 +49,19 @@ describe("once", () => {
 		expect(seen).toEqual([1]);
 	});
 
+	it("rethrows the first failure without invoking the function again", () => {
+		const failure = new Error("initialization failed");
+		let calls = 0;
+		const wrapped = once((): string => {
+			calls++;
+			throw failure;
+		});
+
+		expect(() => wrapped()).toThrow(failure);
+		expect(() => wrapped()).toThrow(failure);
+		expect(calls).toBe(1);
+	});
+
 	// =============================================================================
 	// Types: the wrapper mirrors the wrapped function's signature
 	// =============================================================================

--- a/src/function.ts
+++ b/src/function.ts
@@ -1,7 +1,8 @@
 /**
  * Run-at-most-once wrapper. Wrap `fn` so the first call invokes it and caches the result;
  * every later call is a no-op that returns that same cached result. Arguments passed after
- * the first call are ignored.
+ * the first call are ignored. If the first call throws, later calls rethrow that same value
+ * without invoking `fn` again.
  *
  * Canonical use: an idempotent `[Symbol.dispose]` whose teardown is reachable from more than
  * one path and must not run twice. `once` makes that guarantee declarative instead of a
@@ -32,12 +33,21 @@ export function once<TArgs extends readonly unknown[], TReturn>(
 	fn: (...args: TArgs) => TReturn,
 ): (...args: TArgs) => TReturn {
 	let called = false;
+	let failed = false;
+	let thrown: unknown;
 	let result: TReturn;
 	return (...args: TArgs): TReturn => {
 		if (!called) {
 			called = true;
-			result = fn(...args);
+			try {
+				result = fn(...args);
+			} catch (error) {
+				failed = true;
+				thrown = error;
+				throw error;
+			}
 		}
+		if (failed) throw thrown;
 		return result;
 	};
 }


### PR DESCRIPTION
## Summary

I patched this small edge case found it hand so I decided to put together a quick PR.

If the first call to once() throws, later calls currently return undefined despite the declared return type. This happens because called is set before the result is assigned.

This PR caches and rethrows the original failure while preserving the “run at most once” behavior.

## Changes

- Cache and rethrow the first call’s failure
- Document the failure behavior
- Add a regression test
- Add a patch changeset

## Verification

- bun test : 159 passed
- bun run typecheck
- bun run build
- Biome check on changed files